### PR TITLE
new narrow and widen overloads for input string count

### DIFF
--- a/include/boost/nowide/convert.hpp
+++ b/include/boost/nowide/convert.hpp
@@ -119,6 +119,15 @@ namespace nowide {
         return boost::locale::conv::utf_to_utf<char>(s);
     }
     ///
+    /// Convert between Wide - UTF-16/32 string and UTF-8 string.
+    ///
+    /// boost::locale::conv::conversion_error is thrown in a case of a error
+    ///
+    inline std::string narrow(wchar_t const *s, size_t input_count)
+    {
+        return nowide::conv::utf_to_utf<char>(s, s+input_count);
+    }
+    ///
     /// Convert between UTF-8 and UTF-16 string, implemented only on Windows platform
     ///
     /// boost::locale::conv::conversion_error is thrown in a case of a error
@@ -126,6 +135,15 @@ namespace nowide {
     inline std::wstring widen(char const *s)
     {
         return boost::locale::conv::utf_to_utf<wchar_t>(s);
+    }
+    ///
+    /// Convert between UTF-8 and UTF-16 string, implemented only on Windows platform
+    ///
+    /// nowide::conv::conversion_error is thrown in a case of a error
+    ///
+    inline std::wstring widen(char const *s, size_t input_count)
+    {
+        return nowide::conv::utf_to_utf<wchar_t>(s, s+input_count);
     }
     ///
     /// Convert between Wide - UTF-16/32 string and UTF-8 string

--- a/include/boost/nowide/convert.hpp
+++ b/include/boost/nowide/convert.hpp
@@ -125,7 +125,7 @@ namespace nowide {
     ///
     inline std::string narrow(wchar_t const *s, size_t input_count)
     {
-        return nowide::conv::utf_to_utf<char>(s, s+input_count);
+        return boost::locale::conv::utf_to_utf<char>(s, s+input_count);
     }
     ///
     /// Convert between UTF-8 and UTF-16 string, implemented only on Windows platform
@@ -143,7 +143,7 @@ namespace nowide {
     ///
     inline std::wstring widen(char const *s, size_t input_count)
     {
-        return nowide::conv::utf_to_utf<wchar_t>(s, s+input_count);
+        return boost::locale::conv::utf_to_utf<wchar_t>(s, s+input_count);
     }
     ///
     /// Convert between Wide - UTF-16/32 string and UTF-8 string


### PR DESCRIPTION
New narrow and widen overloads accept count of input string and returns std::string or std::wstring.

Useful for situations where you might not have a null-terminated string, but don't want to wrap it in a std::string or std::wstring
