### PR TITLE
Windows: Support filesystem::path in fstream

### DIFF
--- a/doc/main.md
+++ b/doc/main.md
@@ -305,12 +305,11 @@ and usage via \c string_or_path.c_str() is still possible and portable.
 
 \subsection technical_cio Console I/O
 
-Console I/O is implemented as a wrapper around ReadConsoleW/WriteConsoleW
-(used when the stream goes to the "real" console) and ReadFile/WriteFile
-(used when the stream was piped/redirected).
+Console I/O is implemented as a wrapper around ReadConsoleW/WriteConsoleW when the stream goes to the "real" console.
+When the stream was piped/redirected the standard \c cin/cout is used instead.
 
-This approach eliminates a need of manual code page handling. If TrueType
-fonts are used the Unicode aware input and output works as intended.
+This approach eliminates a need of manual code page handling.
+If TrueType fonts are used the Unicode aware input and output works as intended.
 
 \section qna Q & A
 

--- a/doc/main.md
+++ b/doc/main.md
@@ -287,6 +287,22 @@ using std::fopen
 } // boost
 \endcode
 
+There is also a \c std::filebuf compatible implementation provided for Windows which supports UTF-8 filepaths
+for \c open and behaves otherwise identical (API-wise).
+
+On all systems the \c std::fstream class and friends are provided as custom implementations supporting
+\c std::string and \c \*::filesystem::path as well as \c wchar_t\* (Windows only) overloads for the
+constructor and \c open.
+This is done so users can use e.g. \c boost::filesystem::path with \c boost::nowide::fstream without
+depending on C++17 support.
+Furthermore any path-like class is supported if it matches the interface of \c std::filesystem::path "enough".
+
+Note that there is no universal support for \c path and \c std::string in \c boost::nowide::filebuf.
+This is due to using the std variant on non-Windows systems which might be faster in some cases.
+As \c filebuf is rarely used by user code but rather indirectly through \c fstream not having string or
+path support seems a small price to pay especially as C++11 adds \c std::string support, C++17 \c path support
+and usage via \c string_or_path.c_str() is still possible and portable.
+
 \subsection technical_cio Console I/O
 
 Console I/O is implemented as a wrapper around ReadConsoleW/WriteConsoleW

--- a/include/boost/nowide/config.hpp
+++ b/include/boost/nowide/config.hpp
@@ -70,4 +70,14 @@
 #define BOOST_NOWIDE_FALLTHROUGH BOOST_FALLTHROUGH
 #endif
 
+namespace boost {
+///
+/// \brief This namespace includes implementations of the standard library functions and
+/// classes such that they accept UTF-8 strings on Windows.
+/// On other platforms (i.e. not on Windows) those functions and classes are just aliases
+/// of the corresponding ones from the std namespace or behave like them.
+///
+namespace nowide {}
+} // namespace boost
+
 #endif // boost/nowide/config.hpp

--- a/include/boost/nowide/filebuf.hpp
+++ b/include/boost/nowide/filebuf.hpp
@@ -87,6 +87,12 @@ namespace nowide {
         ///
         basic_filebuf* open(const char* s, std::ios_base::openmode mode)
         {
+            const wstackstring name(s);
+            return open(name.get(), mode);
+        }
+        /// Opens the file with the given name, see std::filebuf::open
+        basic_filebuf* open(const wchar_t* s, std::ios_base::openmode mode)
+        {
             if(is_open())
                 return NULL;
             validate_cvt(this->getloc());
@@ -97,11 +103,11 @@ namespace nowide {
             if(!smode)
                 return 0;
 #ifdef BOOST_WINDOWS
-            const wstackstring name(s);
-            file_ = ::_wfopen(name.get(), smode);
+            file_ = ::_wfopen(s, smode);
 #else
-            short_stackstring smode2(smode);
-            file_ = std::fopen(s, smode2.get());
+            const stackstring name(s);
+            const short_stackstring smode2(smode);
+            file_ = std::fopen(name.get(), smode2.get());
 #endif
 
             if(!file_)

--- a/include/boost/nowide/fstream.hpp
+++ b/include/boost/nowide/fstream.hpp
@@ -34,67 +34,66 @@ namespace nowide {
     using std::fstream;
 
 #else
+    /// \cond INTERNAL
+    namespace detail {
+        // clang-format off
+        struct StreamTypeIn
+        {
+            static std::ios_base::openmode mode() { return std::ios_base::in; }
+            static std::ios_base::openmode mode_modifier() { return mode(); }
+        };
+        struct StreamTypeOut
+        {
+            static std::ios_base::openmode mode() { return std::ios_base::out; }
+            static std::ios_base::openmode mode_modifier() { return mode(); }
+        };
+        struct StreamTypeInOut
+        {
+            static std::ios_base::openmode mode() { return std::ios_base::in | std::ios_base::out; }
+            static std::ios_base::openmode mode_modifier() { return std::ios_base::openmode(); }
+        };
+        // clang-format on
+
+        /// CRTP Base class for all basic_*fstream classes
+        /// Contains basic_filebuf instance so its pointer can be used to construct basic_*stream
+        /// Provides common functions to reduce boilerplate code
+        /// \tparam T_StreamType One of StreamType* above.
+        ///         Class used instead of value, because openmode::operator| may not be constexpr
+        template<typename T_Basic_FStream, typename T_StreamType>
+        class fstream_impl;
+    } // namespace detail
+    /// \endcond
+
     ///
     /// \brief Same as std::basic_ifstream<char> but accepts UTF-8 strings under Windows
     ///
     template<typename CharType, typename Traits = std::char_traits<CharType> >
-    class basic_ifstream : public std::basic_istream<CharType, Traits>
+    class basic_ifstream : public detail::fstream_impl<basic_ifstream<CharType, Traits>, detail::StreamTypeIn>,
+                           public std::basic_istream<CharType, Traits>
     {
-    public:
-        typedef basic_filebuf<CharType, Traits> internal_buffer_type;
-        typedef std::basic_istream<CharType, Traits> internal_stream_type;
+        typedef detail::fstream_impl<basic_ifstream, detail::StreamTypeIn> fstream_impl;
+        typedef std::basic_istream<CharType, Traits> stream_base;
 
-        basic_ifstream() : internal_stream_type(NULL)
-        {
-            this->init(&buf_);
-        }
+    public:
+        basic_ifstream() : stream_base(&this->buf_)
+        {}
 
         explicit basic_ifstream(const char* file_name, std::ios_base::openmode mode = std::ios_base::in) :
-            internal_stream_type(NULL)
+            stream_base(&this->buf_)
         {
-            this->init(&buf_);
             open(file_name, mode);
         }
 
         explicit basic_ifstream(const std::string& file_name, std::ios_base::openmode mode = std::ios_base::in) :
-            internal_stream_type(NULL)
+            stream_base(&this->buf_)
         {
-            this->init(&buf_);
             open(file_name, mode);
         }
 
-        void open(const std::string& file_name, std::ios_base::openmode mode = std::ios_base::in)
-        {
-            open(file_name.c_str(), mode);
-        }
-        void open(const char* file_name, std::ios_base::openmode mode = std::ios_base::in)
-        {
-            if(!buf_.open(file_name, mode | std::ios_base::in))
-                this->setstate(std::ios_base::failbit);
-            else
-                this->clear();
-        }
-        bool is_open()
-        {
-            return buf_.is_open();
-        }
-        bool is_open() const
-        {
-            return buf_.is_open();
-        }
-        void close()
-        {
-            if(!buf_.close())
-                this->setstate(std::ios_base::failbit);
-        }
-
-        internal_buffer_type* rdbuf() const
-        {
-            return const_cast<internal_buffer_type*>(&buf_);
-        }
-
-    private:
-        internal_buffer_type buf_;
+        using fstream_impl::open;
+        using fstream_impl::is_open;
+        using fstream_impl::close;
+        using fstream_impl::rdbuf;
     };
 
     ///
@@ -102,60 +101,30 @@ namespace nowide {
     ///
 
     template<typename CharType, typename Traits = std::char_traits<CharType> >
-    class basic_ofstream : public std::basic_ostream<CharType, Traits>
+    class basic_ofstream : public detail::fstream_impl<basic_ofstream<CharType, Traits>, detail::StreamTypeOut>,
+                           public std::basic_ostream<CharType, Traits>
     {
-    public:
-        typedef basic_filebuf<CharType, Traits> internal_buffer_type;
-        typedef std::basic_ostream<CharType, Traits> internal_stream_type;
+        typedef detail::fstream_impl<basic_ofstream, detail::StreamTypeOut> fstream_impl;
+        typedef std::basic_ostream<CharType, Traits> stream_base;
 
-        basic_ofstream() : internal_stream_type(NULL)
-        {
-            this->init(&buf_);
-        }
+    public:
+        basic_ofstream() : stream_base(&this->buf_)
+        {}
         explicit basic_ofstream(const char* file_name, std::ios_base::openmode mode = std::ios_base::out) :
-            internal_stream_type(NULL)
+            stream_base(&this->buf_)
         {
-            this->init(&buf_);
             open(file_name, mode);
         }
         explicit basic_ofstream(const std::string& file_name, std::ios_base::openmode mode = std::ios_base::out) :
-            internal_stream_type(NULL)
+            stream_base(&this->buf_)
         {
-            this->init(&buf_);
             open(file_name, mode);
         }
-        void open(const std::string& file_name, std::ios_base::openmode mode = std::ios_base::out)
-        {
-            open(file_name.c_str(), mode);
-        }
-        void open(const char* file_name, std::ios_base::openmode mode = std::ios_base::out)
-        {
-            if(!buf_.open(file_name, mode | std::ios_base::out))
-                this->setstate(std::ios_base::failbit);
-            else
-                this->clear();
-        }
-        bool is_open()
-        {
-            return buf_.is_open();
-        }
-        bool is_open() const
-        {
-            return buf_.is_open();
-        }
-        void close()
-        {
-            if(!buf_.close())
-                this->setstate(std::ios_base::failbit);
-        }
 
-        internal_buffer_type* rdbuf() const
-        {
-            return const_cast<internal_buffer_type*>(&buf_);
-        }
-
-    private:
-        internal_buffer_type buf_;
+        using fstream_impl::open;
+        using fstream_impl::is_open;
+        using fstream_impl::close;
+        using fstream_impl::rdbuf;
     };
 
 #ifdef BOOST_MSVC
@@ -166,62 +135,32 @@ namespace nowide {
     /// \brief Same as std::basic_fstream<char> but accepts UTF-8 strings under Windows
     ///
     template<typename CharType, typename Traits = std::char_traits<CharType> >
-    class basic_fstream : public std::basic_iostream<CharType, Traits>
+    class basic_fstream : public detail::fstream_impl<basic_fstream<CharType, Traits>, detail::StreamTypeInOut>,
+                          public std::basic_iostream<CharType, Traits>
     {
-    public:
-        typedef basic_filebuf<CharType, Traits> internal_buffer_type;
-        typedef std::basic_iostream<CharType, Traits> internal_stream_type;
+        typedef detail::fstream_impl<basic_fstream, detail::StreamTypeInOut> fstream_impl;
+        typedef std::basic_iostream<CharType, Traits> stream_base;
 
-        basic_fstream() : internal_stream_type(NULL)
-        {
-            this->init(&buf_);
-        }
+    public:
+        basic_fstream() : stream_base(&this->buf_)
+        {}
         explicit basic_fstream(const char* file_name,
                                std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out) :
-            internal_stream_type(NULL)
+            stream_base(&this->buf_)
         {
-            this->init(&buf_);
             open(file_name, mode);
         }
         explicit basic_fstream(const std::string& file_name,
                                std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out) :
-            internal_stream_type(NULL)
+            stream_base(&this->buf_)
         {
-            this->init(&buf_);
             open(file_name, mode);
         }
-        void open(const std::string& file_name, std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out)
-        {
-            open(file_name.c_str(), mode);
-        }
-        void open(const char* file_name, std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out)
-        {
-            if(!buf_.open(file_name, mode))
-                this->setstate(std::ios_base::failbit);
-            else
-                this->clear();
-        }
-        bool is_open()
-        {
-            return buf_.is_open();
-        }
-        bool is_open() const
-        {
-            return buf_.is_open();
-        }
-        void close()
-        {
-            if(!buf_.close())
-                this->setstate(std::ios_base::failbit);
-        }
 
-        internal_buffer_type* rdbuf() const
-        {
-            return const_cast<internal_buffer_type*>(&buf_);
-        }
-
-    private:
-        internal_buffer_type buf_;
+        using fstream_impl::open;
+        using fstream_impl::is_open;
+        using fstream_impl::close;
+        using fstream_impl::rdbuf;
     };
 #ifdef BOOST_MSVC
 #pragma warning(pop)
@@ -244,6 +183,56 @@ namespace nowide {
     ///
     typedef basic_fstream<char> fstream;
 
+    // Implementation
+    namespace detail {
+        template<template<typename, typename> class T_Basic_FStream,
+                 typename CharType,
+                 typename Traits,
+                 typename T_StreamType>
+        class fstream_impl<T_Basic_FStream<CharType, Traits>, T_StreamType>
+        {
+            typedef T_Basic_FStream<CharType, Traits> Underlying;
+            typedef basic_filebuf<CharType, Traits> internal_buffer_type;
+
+            Underlying* underlying()
+            {
+                return static_cast<Underlying*>(this);
+            }
+
+        protected:
+            void open(const std::string& file_name, std::ios_base::openmode mode = T_StreamType::mode())
+            {
+                open(file_name.c_str(), mode);
+            }
+            void open(const char* file_name, std::ios_base::openmode mode = T_StreamType::mode())
+            {
+                if(!buf_.open(file_name, mode | T_StreamType::mode_modifier()))
+                    underlying()->setstate(std::ios_base::failbit);
+                else
+                    underlying()->clear();
+            }
+            bool is_open()
+            {
+                return buf_.is_open();
+            }
+            bool is_open() const
+            {
+                return buf_.is_open();
+            }
+            void close()
+            {
+                if(!buf_.close())
+                    underlying()->setstate(std::ios_base::failbit);
+            }
+
+            internal_buffer_type* rdbuf() const
+            {
+                return const_cast<internal_buffer_type*>(&this->buf_);
+            }
+
+            internal_buffer_type buf_;
+        };
+    } // namespace detail
 #endif
 } // namespace nowide
 } // namespace boost

--- a/include/boost/nowide/fstream.hpp
+++ b/include/boost/nowide/fstream.hpp
@@ -22,22 +22,35 @@ namespace nowide {
         {
             static std::ios_base::openmode mode() { return std::ios_base::in; }
             static std::ios_base::openmode mode_modifier() { return mode(); }
+            template<typename CharType, typename Traits>
+            struct stream_base{
+                typedef std::basic_istream<CharType, Traits> type;
+            };
         };
         struct StreamTypeOut
         {
             static std::ios_base::openmode mode() { return std::ios_base::out; }
             static std::ios_base::openmode mode_modifier() { return mode(); }
+            template<typename CharType, typename Traits>
+            struct stream_base{
+                typedef std::basic_ostream<CharType, Traits> type;
+            };
         };
         struct StreamTypeInOut
         {
             static std::ios_base::openmode mode() { return std::ios_base::in | std::ios_base::out; }
             static std::ios_base::openmode mode_modifier() { return std::ios_base::openmode(); }
+            template<typename CharType, typename Traits>
+            struct stream_base{
+                typedef std::basic_iostream<CharType, Traits> type;
+            };
         };
         // clang-format on
 
         /// CRTP Base class for all basic_*fstream classes
         /// Contains basic_filebuf instance so its pointer can be used to construct basic_*stream
-        /// Provides common functions to reduce boilerplate code
+        /// Provides common functions to reduce boilerplate code including inheriting from
+        /// the correct std::basic_[io]stream class and initializing it
         /// \tparam T_StreamType One of StreamType* above.
         ///         Class used instead of value, because openmode::operator| may not be constexpr
         template<typename T_Basic_FStream, typename T_StreamType>
@@ -52,31 +65,26 @@ namespace nowide {
     /// \brief Same as std::basic_ifstream<char> but accepts UTF-8 strings under Windows
     ///
     template<typename CharType, typename Traits = std::char_traits<CharType> >
-    class basic_ifstream : public detail::fstream_impl<basic_ifstream<CharType, Traits>, detail::StreamTypeIn>,
-                           public std::basic_istream<CharType, Traits>
+    class basic_ifstream : public detail::fstream_impl<basic_ifstream<CharType, Traits>, detail::StreamTypeIn>
     {
         typedef detail::fstream_impl<basic_ifstream, detail::StreamTypeIn> fstream_impl;
-        typedef std::basic_istream<CharType, Traits> stream_base;
 
     public:
-        basic_ifstream() : stream_base(&this->buf_)
+        basic_ifstream()
         {}
 
-        explicit basic_ifstream(const char* file_name, std::ios_base::openmode mode = std::ios_base::in) :
-            stream_base(&this->buf_)
+        explicit basic_ifstream(const char* file_name, std::ios_base::openmode mode = std::ios_base::in)
         {
             open(file_name, mode);
         }
 #ifdef BOOST_WINDOWS
-        explicit basic_ifstream(const wchar_t* file_name, std::ios_base::openmode mode = std::ios_base::in) :
-            stream_base(&this->buf_)
+        explicit basic_ifstream(const wchar_t* file_name, std::ios_base::openmode mode = std::ios_base::in)
         {
             open(file_name, mode);
         }
 #endif
 
-        explicit basic_ifstream(const std::string& file_name, std::ios_base::openmode mode = std::ios_base::in) :
-            stream_base(&this->buf_)
+        explicit basic_ifstream(const std::string& file_name, std::ios_base::openmode mode = std::ios_base::in)
         {
             open(file_name, mode);
         }
@@ -84,8 +92,7 @@ namespace nowide {
         template<typename Path>
         explicit basic_ifstream(
           const Path& file_name,
-          typename detail::enable_if_path<Path, std::ios_base::openmode>::type mode = std::ios_base::in) :
-            stream_base(&this->buf_)
+          typename detail::enable_if_path<Path, std::ios_base::openmode>::type mode = std::ios_base::in)
         {
             open(file_name, mode);
         }
@@ -100,37 +107,31 @@ namespace nowide {
     ///
 
     template<typename CharType, typename Traits = std::char_traits<CharType> >
-    class basic_ofstream : public detail::fstream_impl<basic_ofstream<CharType, Traits>, detail::StreamTypeOut>,
-                           public std::basic_ostream<CharType, Traits>
+    class basic_ofstream : public detail::fstream_impl<basic_ofstream<CharType, Traits>, detail::StreamTypeOut>
     {
         typedef detail::fstream_impl<basic_ofstream, detail::StreamTypeOut> fstream_impl;
-        typedef std::basic_ostream<CharType, Traits> stream_base;
 
     public:
-        basic_ofstream() : stream_base(&this->buf_)
+        basic_ofstream()
         {}
-        explicit basic_ofstream(const char* file_name, std::ios_base::openmode mode = std::ios_base::out) :
-            stream_base(&this->buf_)
+        explicit basic_ofstream(const char* file_name, std::ios_base::openmode mode = std::ios_base::out)
         {
             open(file_name, mode);
         }
 #ifdef BOOST_WINDOWS
-        explicit basic_ofstream(const wchar_t* file_name, std::ios_base::openmode mode = std::ios_base::out) :
-            stream_base(&this->buf_)
+        explicit basic_ofstream(const wchar_t* file_name, std::ios_base::openmode mode = std::ios_base::out)
         {
             open(file_name, mode);
         }
 #endif
-        explicit basic_ofstream(const std::string& file_name, std::ios_base::openmode mode = std::ios_base::out) :
-            stream_base(&this->buf_)
+        explicit basic_ofstream(const std::string& file_name, std::ios_base::openmode mode = std::ios_base::out)
         {
             open(file_name, mode);
         }
         template<typename Path>
         explicit basic_ofstream(
           const Path& file_name,
-          typename detail::enable_if_path<Path, std::ios_base::openmode>::type mode = std::ios_base::out) :
-            stream_base(&this->buf_)
+          typename detail::enable_if_path<Path, std::ios_base::openmode>::type mode = std::ios_base::out)
         {
             open(file_name, mode);
         }
@@ -149,40 +150,34 @@ namespace nowide {
     /// \brief Same as std::basic_fstream<char> but accepts UTF-8 strings under Windows
     ///
     template<typename CharType, typename Traits = std::char_traits<CharType> >
-    class basic_fstream : public detail::fstream_impl<basic_fstream<CharType, Traits>, detail::StreamTypeInOut>,
-                          public std::basic_iostream<CharType, Traits>
+    class basic_fstream : public detail::fstream_impl<basic_fstream<CharType, Traits>, detail::StreamTypeInOut>
     {
         typedef detail::fstream_impl<basic_fstream, detail::StreamTypeInOut> fstream_impl;
-        typedef std::basic_iostream<CharType, Traits> stream_base;
 
     public:
-        basic_fstream() : stream_base(&this->buf_)
+        basic_fstream()
         {}
         explicit basic_fstream(const char* file_name,
-                               std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out) :
-            stream_base(&this->buf_)
+                               std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out)
         {
             open(file_name, mode);
         }
 #ifdef BOOST_WINDOWS
         explicit basic_fstream(const wchar_t* file_name,
-                               std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out) :
-            stream_base(&this->buf_)
+                               std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out)
         {
             open(file_name, mode);
         }
 #endif
         explicit basic_fstream(const std::string& file_name,
-                               std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out) :
-            stream_base(&this->buf_)
+                               std::ios_base::openmode mode = std::ios_base::in | std::ios_base::out)
         {
             open(file_name, mode);
         }
         template<typename Path>
         explicit basic_fstream(const Path& file_name,
                                typename detail::enable_if_path<Path, std::ios_base::openmode>::type mode =
-                                 std::ios_base::in | std::ios_base::out) :
-            stream_base(&this->buf_)
+                                 std::ios_base::in | std::ios_base::out)
         {
             open(file_name, mode);
         }
@@ -218,21 +213,32 @@ namespace nowide {
 
     // Implementation
     namespace detail {
+        /// Holds an instance of T
+        /// Required to make sure this is constructed first before passing it to sibling classes
+        template<typename T>
+        struct buf_holder
+        {
+            T buf_;
+        };
         template<template<typename, typename> class T_Basic_FStream,
                  typename CharType,
                  typename Traits,
                  typename T_StreamType>
         class fstream_impl<T_Basic_FStream<CharType, Traits>, T_StreamType>
+            : private buf_holder<basic_filebuf<CharType, Traits> >, // must be first due to init order
+              public T_StreamType::template stream_base<CharType, Traits>::type
         {
-            typedef T_Basic_FStream<CharType, Traits> Underlying;
             typedef basic_filebuf<CharType, Traits> internal_buffer_type;
+            typedef typename T_StreamType::template stream_base<CharType, Traits>::type stream_base;
 
-            Underlying* underlying()
-            {
-                return static_cast<Underlying*>(this);
-            }
+        public:
+            using stream_base::setstate;
+            using stream_base::clear;
 
         protected:
+            fstream_impl() : stream_base(rdbuf())
+            {}
+
             void open(const std::string& file_name, std::ios_base::openmode mode = T_StreamType::mode())
             {
                 open(file_name.c_str(), mode);
@@ -245,40 +251,40 @@ namespace nowide {
             }
             void open(const char* file_name, std::ios_base::openmode mode = T_StreamType::mode())
             {
-                if(!buf_.open(file_name, mode | T_StreamType::mode_modifier()))
-                    underlying()->setstate(std::ios_base::failbit);
+                if(!rdbuf()->open(file_name, mode | T_StreamType::mode_modifier()))
+                    setstate(std::ios_base::failbit);
                 else
-                    underlying()->clear();
+                    clear();
             }
 #ifdef BOOST_WINDOWS
             void open(const wchar_t* file_name, std::ios_base::openmode mode = T_StreamType::mode())
             {
-                if(!buf_.open(file_name, mode | T_StreamType::mode_modifier()))
-                    underlying()->setstate(std::ios_base::failbit);
+                if(!rdbuf()->open(file_name, mode | T_StreamType::mode_modifier()))
+                    setstate(std::ios_base::failbit);
                 else
-                    underlying()->clear();
+                    clear();
             }
 #endif
             bool is_open()
             {
-                return buf_.is_open();
+                return rdbuf()->is_open();
             }
             bool is_open() const
             {
-                return buf_.is_open();
+                return rdbuf()->is_open();
             }
             void close()
             {
-                if(!buf_.close())
-                    underlying()->setstate(std::ios_base::failbit);
+                if(!rdbuf()->close())
+                    setstate(std::ios_base::failbit);
             }
 
             internal_buffer_type* rdbuf() const
             {
-                return const_cast<internal_buffer_type*>(&this->buf_);
+                return const_cast<internal_buffer_type*>(&buf_.buf_);
             }
 
-            internal_buffer_type buf_;
+            buf_holder<internal_buffer_type> buf_;
         };
 
         /// Trait to heuristically check for a *::filesystem::path

--- a/test/test_fs.cpp
+++ b/test/test_fs.cpp
@@ -10,7 +10,6 @@
 #include <boost/nowide/cstdio.hpp>
 #include <boost/nowide/fstream.hpp>
 #include <boost/nowide/integration/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <iostream>
 
@@ -25,10 +24,11 @@ int main()
         const std::string utf8_name =
           prefix + "\xf0\x9d\x92\x9e-\xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82-\xE3\x82\x84\xE3\x81\x82.txt";
 
-        boost::nowide::ofstream f(utf8_name.c_str());
-        TEST(f);
-        f << "Test" << std::endl;
-        f.close();
+        {
+            boost::nowide::ofstream f(utf8_name.c_str());
+            TEST(f);
+            f << "Test" << std::endl;
+        }
 
         TEST(boost::filesystem::is_regular_file(boost::nowide::widen(utf8_name)));
         TEST(boost::filesystem::is_regular_file(utf8_name));
@@ -37,6 +37,29 @@ int main()
 
         TEST(!boost::filesystem::is_regular_file(boost::nowide::widen(utf8_name)));
         TEST(!boost::filesystem::is_regular_file(utf8_name));
+
+        const boost::filesystem::path path = utf8_name;
+        {
+            boost::nowide::ofstream f(path);
+            TEST(f);
+            f << "Test" << std::endl;
+            TEST(is_regular_file(path));
+        }
+        {
+            boost::nowide::ifstream f(path);
+            TEST(f);
+            std::string test;
+            f >> test;
+            TEST(test == "Test");
+        }
+        {
+            boost::nowide::fstream f(path);
+            TEST(f);
+            std::string test;
+            f >> test;
+            TEST(test == "Test");
+        }
+        boost::filesystem::remove(path);
     } catch(const std::exception& e)
     {
         std::cerr << "Failed : " << e.what() << std::endl;

--- a/test/test_fstream.cpp
+++ b/test/test_fstream.cpp
@@ -221,7 +221,7 @@ void test_ofstream_write(const char* filename)
     TEST(file_contents_equal(filename, "test2\n"));
     TEST(nw::remove(filename) == 0);
     // C++11 interfaces aren't enabled at all platforms so need to skip std::string arg for std::*fstream
-#if defined(BOOST_WINDOWS)
+#if defined(BOOST_WINDOWS) || defined(BOOST_NOWIDE_USE_FSTREAM_REPLACEMENTS)
     // string ctor
     {
         std::string name = filename;
@@ -285,7 +285,7 @@ void test_ifstream_open_read(const char* filename)
         TEST(tmp == "test");
     }
     // C++11 interfaces aren't enabled at all platforms so need to skip std::string arg for std::*fstream
-#if defined(BOOST_WINDOWS)
+#if defined(BOOST_WINDOWS) || defined(BOOST_NOWIDE_USE_FSTREAM_REPLACEMENTS)
     // string ctor
     {
         std::string name = filename;
@@ -438,8 +438,7 @@ void test_fstream(const char* filename)
 template<typename T>
 bool is_open(T& stream)
 {
-    // There const are and const non versions of is_open
-    // Test both
+    // There are const and non const versions of is_open, so test both
     TEST(stream.is_open() == const_cast<const T&>(stream).is_open());
     return stream.is_open();
 }

--- a/test/test_fstream.cpp
+++ b/test/test_fstream.cpp
@@ -220,8 +220,6 @@ void test_ofstream_write(const char* filename)
     }
     TEST(file_contents_equal(filename, "test2\n"));
     TEST(nw::remove(filename) == 0);
-    // C++11 interfaces aren't enabled at all platforms so need to skip std::string arg for std::*fstream
-#if defined(BOOST_WINDOWS) || defined(BOOST_NOWIDE_USE_FSTREAM_REPLACEMENTS)
     // string ctor
     {
         std::string name = filename;
@@ -238,7 +236,6 @@ void test_ofstream_write(const char* filename)
     }
     TEST(file_contents_equal(filename, "test2\n"));
     TEST(nw::remove(filename) == 0);
-#endif
     // Binary mode
     {
         nw::ofstream fo(filename, std::ios::binary);
@@ -284,8 +281,6 @@ void test_ifstream_open_read(const char* filename)
         TEST(fi >> tmp);
         TEST(tmp == "test");
     }
-    // C++11 interfaces aren't enabled at all platforms so need to skip std::string arg for std::*fstream
-#if defined(BOOST_WINDOWS) || defined(BOOST_NOWIDE_USE_FSTREAM_REPLACEMENTS)
     // string ctor
     {
         std::string name = filename;
@@ -304,7 +299,6 @@ void test_ifstream_open_read(const char* filename)
         TEST(fi >> tmp);
         TEST(tmp == "test");
     }
-#endif
     // Binary mode
     {
         nw::ifstream fi(filename, std::ios::binary);
@@ -338,16 +332,21 @@ void test_ifstream_open_read(const char* filename)
 
 void test_fstream(const char* filename)
 {
+    const std::string sFilename = filename;
     nw::remove(filename);
     TEST(!file_exists(filename));
     // Fail on non-existing file
     {
         nw::fstream f(filename);
         TEST(!f);
+        nw::fstream f2(sFilename);
+        TEST(!f2);
     }
     {
         nw::fstream f;
         f.open(filename);
+        TEST(!f);
+        f.open(sFilename);
         TEST(!f);
     }
     TEST(!file_exists(filename));
@@ -357,7 +356,7 @@ void test_fstream(const char* filename)
         TEST(f);
     }
     TEST(file_contents_equal(filename, ""));
-    // Ctor
+    // Char* ctor
     {
         nw::fstream f(filename);
         TEST(f);
@@ -368,6 +367,17 @@ void test_fstream(const char* filename)
         TEST(tmp == "test");
     }
     TEST(file_contents_equal(filename, "test"));
+    // String ctor
+    {
+        nw::fstream f(sFilename);
+        TEST(f);
+        TEST(f << "string_ctor");
+        std::string tmp;
+        TEST(f.seekg(0));
+        TEST(f >> tmp);
+        TEST(tmp == "string_ctor");
+    }
+    TEST(file_contents_equal(filename, "string_ctor"));
     TEST(nw::remove(filename) == 0);
     // Create empty file (open)
     {


### PR DESCRIPTION
This adds wchar_t overloads to fstream and filebuf which allows better integration with {boost,std}::filesystem::path and is mandated by C++17 on Windows.

This is then used to accept *::filesystem::path parameters for fstream classes.
