### PR TITLE
Add exceptions if winApi calls fail

### DIFF
--- a/include/boost/nowide/args.hpp
+++ b/include/boost/nowide/args.hpp
@@ -86,26 +86,46 @@ namespace nowide {
                 *old_env_ptr_ = old_env_;
         }
     private:
+        class wargv_ptr
+        {
+            wchar_t **p;
+            int argc;
+            wargv_ptr(const wargv_ptr &); // Non-copyable
+        public:
+            explicit wargv_ptr(const wchar_t *cmd_line) : p(CommandLineToArgvW(GetCommandLineW(), &argc)) {}
+            ~wargv_ptr() { if(p) LocalFree(p); }
+            int size() const { return argc; }
+            operator bool() const { return p != NULL; }
+            const wchar_t* operator[](size_t i) const { return p[i]; }
+        };
+        class wenv_ptr
+        {
+            wchar_t *p;
+            wenv_ptr(const wenv_ptr &); // Non-copyable
+        public:
+            wenv_ptr() : p(GetEnvironmentStringsW()) {}
+            ~wenv_ptr() { if(p) FreeEnvironmentStringsW(p); }
+            operator const wchar_t*() const { return p; }
+        };
+
         void fix_args(int &argc,char **&argv)
         {
-            int wargc;
-            wchar_t **wargv = CommandLineToArgvW(GetCommandLineW(),&wargc);
+            const wargv_ptr wargv(GetCommandLineW());
             if(!wargv)
                 throw std::runtime_error("Could not get command line!");
-            args_.resize(wargc+1,0);
-            arg_values_.resize(wargc);
-            for(int i=0;i<wargc;i++) 
+            args_.resize(wargv.size()+1,0);
+            arg_values_.resize(wargv.size());
+            for(int i=0;i<wargv.size();i++) 
                 args_[i] = arg_values_[i].convert(wargv[i]);
-            argc = wargc;
+            argc = wargv.size();
             argv = &args_[0];
-            LocalFree(wargv);
         }
         void fix_env(char **&env)
         {
-            wchar_t *wstrings = GetEnvironmentStringsW();
+            const wenv_ptr wstrings;
             if(!wstrings)
                 throw std::runtime_error("Could not get environment strings!");
-            wchar_t *wstrings_end = 0;
+            const wchar_t *wstrings_end = 0;
             int count = 0;
             for(wstrings_end = wstrings;*wstrings_end;wstrings_end+=wcslen(wstrings_end)+1)
                     count++;
@@ -119,7 +139,6 @@ namespace nowide {
                 p+=strlen(p)+1;
             }
             env = &envp_[0];
-            FreeEnvironmentStringsW(wstrings);
         }
 
         std::vector<char *> args_;

--- a/include/boost/nowide/args.hpp
+++ b/include/boost/nowide/args.hpp
@@ -9,10 +9,11 @@
 #define BOOST_NOWIDE_ARGS_HPP_INCLUDED
 
 #include <boost/config.hpp>
+#ifdef BOOST_WINDOWS
 #include <boost/nowide/stackstring.hpp>
 #include <vector>
-#ifdef BOOST_WINDOWS
 #include <boost/nowide/windows.hpp>
+#include <stdexcept>
 #endif
 
 namespace boost {
@@ -84,14 +85,10 @@ namespace nowide {
     private:
         void fix_args(int &argc,char **&argv)
         {
-                int wargc;
-                wchar_t **wargv = CommandLineToArgvW(GetCommandLineW(),&wargc);
-            if(!wargv) {
-                argc = 0;
-                static char *dummy = 0;
-                argv = &dummy;
-                return;
-            }
+            int wargc;
+            wchar_t **wargv = CommandLineToArgvW(GetCommandLineW(),&wargc);
+            if(!wargv)
+                throw std::runtime_error("Could not get command line!");
             try{
                 args_.resize(wargc+1,0);
                 arg_values_.resize(wargc);
@@ -112,7 +109,7 @@ namespace nowide {
             en = &dummy;
             wchar_t *wstrings = GetEnvironmentStringsW();
             if(!wstrings)
-                return;
+                throw std::runtime_error("Could not get environment strings!");
             try {
                 wchar_t *wstrings_end = 0;
                 int count = 0;


### PR DESCRIPTION
Using `args` will no longer silently fail

Fixes #15