### PR TITLE
Fix conversion warnings

### DIFF
--- a/src/iostream.cpp
+++ b/src/iostream.cpp
@@ -50,7 +50,7 @@ namespace details {
         {
             if(!handle_)
                 return -1;
-            int n = pptr() - pbase();
+            int n = static_cast<int>(pptr() - pbase());
             int r = 0;
             
             if(n > 0 && (r=write(pbase(),n)) < 0)
@@ -83,9 +83,9 @@ namespace details {
                 out = uf::utf_traits<wchar_t>::encode(c,out);
                 decoded = p-b;
             }
-            if(!WriteConsoleW(handle_,wbuffer_,out - wbuffer_,&size,0))
+            if(!WriteConsoleW(handle_,wbuffer_,static_cast<DWORD>(out - wbuffer_),&size,0))
                 return -1;
-            return decoded;
+            return static_cast<int>(decoded);
         }
         
         static const int buffer_size = 1024;
@@ -158,7 +158,7 @@ namespace details {
             namespace uf = boost::locale::utf;
             DWORD read_wchars = 0;
             size_t n = wbuffer_size - wsize_;
-            if(!ReadConsoleW(handle_,wbuffer_,n,&read_wchars,0))
+            if(!ReadConsoleW(handle_,wbuffer_,static_cast<DWORD>(n),&read_wchars,0))
                 return 0;
             wsize_ += read_wchars;
             char *out = buffer_;
@@ -188,7 +188,7 @@ namespace details {
         char buffer_[buffer_size];
         wchar_t wbuffer_[buffer_size]; // for null
         HANDLE handle_;
-        int wsize_;
+        size_t wsize_;
         std::vector<char> pback_buffer_;
     };
 


### PR DESCRIPTION
Compiling with VS gives (correctly):

>  ...nowide\src\iostream.cpp(53): warning C4244: 'initializing': conversion from '__int64' to 'int', possible loss of data [...\nowide\src\nowide-static.vcxproj]
>          ...nowide\src\iostream.cpp(86): warning C4244: 'argument': conversion from '__int64' to 'DWORD', possible loss of data [...\nowide\src\nowide-static.vcxproj]
>          ...nowide\src\iostream.cpp(88): warning C4267: 'return': conversion from 'size_t' to 'int', possible loss of data [...\nowide\src\nowide-static.vcxproj]
>          ...nowide\src\iostream.cpp(161): warning C4267: 'argument': conversion from 'size_t' to 'DWORD', possible loss of data [...\nowide\src\nowide-static.vcxproj]
>          ...nowide\src\iostream.cpp(169): warning C4244: '=': conversion from '__int64' to 'int', possible loss of data [...\nowide\src\nowide-static.vcxproj]
>          ...nowide\src\iostream.cpp(172): warning C4244: '=': conversion from '__int64' to 'int', possible loss of data [...\nowide\src\nowide-static.vcxproj]