### PR TITLE
Include C headers with the C++ version

### DIFF
--- a/include/boost/nowide/cenv.hpp
+++ b/include/boost/nowide/cenv.hpp
@@ -10,7 +10,7 @@
 
 #include <string>
 #include <stdexcept>
-#include <stdlib.h>
+#include <cstdlib>
 #include <boost/config.hpp>
 #include <boost/nowide/stackstring.hpp>
 #include <vector>

--- a/include/boost/nowide/cstdio.hpp
+++ b/include/boost/nowide/cstdio.hpp
@@ -9,11 +9,10 @@
 #define BOOST_NOWIDE_CSTDIO_H_INCLUDED
 
 #include <cstdio>
-#include <stdio.h>
 #include <boost/config.hpp>
 #include <boost/nowide/convert.hpp>
 #include <boost/nowide/stackstring.hpp>
-#include <errno.h>
+#include <cerrno>
 
 #ifdef BOOST_MSVC
 #  pragma warning(push)

--- a/include/boost/nowide/filebuf.hpp
+++ b/include/boost/nowide/filebuf.hpp
@@ -13,7 +13,7 @@
 #include <boost/nowide/stackstring.hpp>
 #include <fstream>
 #include <streambuf>
-#include <stdio.h>
+#include <cstdio>
 
 #ifdef BOOST_MSVC
 #  pragma warning(push)

--- a/include/boost/nowide/stackstring.hpp
+++ b/include/boost/nowide/stackstring.hpp
@@ -8,7 +8,7 @@
 #ifndef BOOST_NOWIDE_DETAILS_WIDESTR_H_INCLUDED
 #define BOOST_NOWIDE_DETAILS_WIDESTR_H_INCLUDED
 #include <boost/nowide/convert.hpp>
-#include <string.h>
+#include <cstring>
 #include <algorithm>
 
 namespace boost {

--- a/include/boost/nowide/system.hpp
+++ b/include/boost/nowide/system.hpp
@@ -8,8 +8,8 @@
 #ifndef BOOST_NOWIDE_CSTDLIB_HPP
 #define BOOST_NOWIDE_CSTDLIB_HPP
 
-#include <stdlib.h>
-#include <errno.h>
+#include <cstdlib>
+#include <cerrno>
 #include <boost/nowide/stackstring.hpp>
 namespace boost {
 namespace nowide {

--- a/include/boost/nowide/windows.hpp
+++ b/include/boost/nowide/windows.hpp
@@ -8,7 +8,7 @@
 #ifndef BOOST_NOWIDE_WINDOWS_HPP_INCLUDED
 #define BOOST_NOWIDE_WINDOWS_HPP_INCLUDED
 
-#include <stddef.h>
+#include <cstddef>
 
 #ifdef BOOST_NOWIDE_USE_WINDOWS_H
 #include <windows.h>

--- a/src/iostream.cpp
+++ b/src/iostream.cpp
@@ -8,7 +8,7 @@
 #define BOOST_NOWIDE_SOURCE
 #include <boost/nowide/iostream.hpp>
 #include <boost/nowide/convert.hpp>
-#include <stdio.h>
+#include <cstdio>
 #include <vector>
 
 #ifdef BOOST_WINDOWS

--- a/standalone/scoped_ptr.hpp
+++ b/standalone/scoped_ptr.hpp
@@ -12,7 +12,7 @@
 //  http://www.boost.org/libs/smart_ptr/scoped_ptr.htm
 //
 
-#include <assert.h>
+#include <cassert>
 
 namespace nowide
 {

--- a/standalone/utf.hpp
+++ b/standalone/utf.hpp
@@ -19,7 +19,7 @@ namespace utf {
 }
 }
 #else
-#include <stdint.h>
+#include <cstdint>
 #endif
 
 namespace nowide {

--- a/test/test_codecvt.cpp
+++ b/test/test_codecvt.cpp
@@ -9,8 +9,8 @@
 #include <locale>
 #include <iostream>
 #include <iomanip>
-#include <string.h>
-#include <memory.h>
+#include <cstring>
+#include <cmemory>
 #include "test.hpp"
 
 static char const *utf8_name = "\xf0\x9d\x92\x9e-\xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82-\xE3\x82\x84\xE3\x81\x82.txt";

--- a/test/test_stdio.cpp
+++ b/test/test_stdio.cpp
@@ -8,7 +8,7 @@
 
 #include <boost/nowide/cstdio.hpp>
 #include <iostream>
-#include <string.h>
+#include <cstring>
 #include "test.hpp"
 
 #ifdef BOOST_MSVC

--- a/test/test_system.cpp
+++ b/test/test_system.cpp
@@ -11,7 +11,7 @@
 #include <boost/nowide/cenv.hpp>
 #include <iostream>
 #include "test.hpp"
-#include <stdio.h>
+#include <cstdio>
 
 int main(int argc,char **argv,char **env)
 {


### PR DESCRIPTION
Include C headers with the C++ version like <cstdio> instead of <stdio.h>.

Fixes issue #36 and #37.