### PR TITLE
Fix compile error and warnings

### DIFF
--- a/include/boost/nowide/cenv.hpp
+++ b/include/boost/nowide/cenv.hpp
@@ -101,7 +101,7 @@ namespace nowide {
     {
         char const *key = string;
         char const *key_end = string;
-        while(*key_end!='=' && key_end!='\0')
+        while(*key_end!='=' && *key_end!='\0')
             key_end++;
         if(*key_end == '\0')
             return -1;

--- a/standalone/utf.hpp
+++ b/standalone/utf.hpp
@@ -233,6 +233,7 @@ namespace utf {
                 if (!is_trail(tmp))
                     return illegal;
                 c = (c << 6) | ( tmp & 0x3F);
+                /* fall-through */
             case 2:
                 if(NOWIDE_UNLIKELY(p==e))
                     return incomplete;
@@ -240,6 +241,7 @@ namespace utf {
                 if (!is_trail(tmp))
                     return illegal;
                 c = (c << 6) | ( tmp & 0x3F);
+                /* fall-through */
             case 1:
                 if(NOWIDE_UNLIKELY(p==e))
                     return incomplete;


### PR DESCRIPTION
```
/nowide/cenv.hpp:104:41: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
         while(*key_end!='=' && key_end!='\0')
                                         ^~~~
```
and -Wimplicit-fallthrough warnings