### PR TITLE
Include C++ headers instead of C variants

### DIFF
--- a/include/boost/nowide/cenv.hpp
+++ b/include/boost/nowide/cenv.hpp
@@ -10,7 +10,7 @@
 
 #include <string>
 #include <stdexcept>
-#include <stdlib.h>
+#include <cstdlib>
 #include <boost/config.hpp>
 #include <boost/nowide/stackstring.hpp>
 #include <vector>
@@ -22,7 +22,7 @@
 namespace boost {
 namespace nowide {
     #if !defined(BOOST_WINDOWS) && !defined(BOOST_NOWIDE_DOXYGEN)
-    using ::getenv;
+    using std::getenv;
     using ::setenv;
     using ::unsetenv;
     using ::putenv;

--- a/include/boost/nowide/cstdio.hpp
+++ b/include/boost/nowide/cstdio.hpp
@@ -9,11 +9,9 @@
 #define BOOST_NOWIDE_CSTDIO_H_INCLUDED
 
 #include <cstdio>
-#include <stdio.h>
 #include <boost/config.hpp>
 #include <boost/nowide/convert.hpp>
 #include <boost/nowide/stackstring.hpp>
-#include <errno.h>
 
 #ifdef BOOST_MSVC
 #  pragma warning(push)

--- a/include/boost/nowide/filebuf.hpp
+++ b/include/boost/nowide/filebuf.hpp
@@ -13,7 +13,7 @@
 #include <boost/nowide/stackstring.hpp>
 #include <fstream>
 #include <streambuf>
-#include <stdio.h>
+#include <cstdio>
 
 #ifdef BOOST_MSVC
 #  pragma warning(push)

--- a/include/boost/nowide/stackstring.hpp
+++ b/include/boost/nowide/stackstring.hpp
@@ -8,8 +8,7 @@
 #ifndef BOOST_NOWIDE_DETAILS_WIDESTR_H_INCLUDED
 #define BOOST_NOWIDE_DETAILS_WIDESTR_H_INCLUDED
 #include <boost/nowide/convert.hpp>
-#include <string.h>
-#include <algorithm>
+#include <cstring>
 
 namespace boost {
 namespace nowide {
@@ -40,10 +39,10 @@ public:
             while(other.mem_buffer_[len])
                 len ++;
             mem_buffer_ = new output_char[len + 1];
-            memcpy(mem_buffer_,other.mem_buffer_,sizeof(output_char) * (len+1));
+            std::memcpy(mem_buffer_,other.mem_buffer_,sizeof(output_char) * (len+1));
         }
         else {
-            memcpy(buffer_,other.buffer_,buffer_size * sizeof(output_char));
+            std::memcpy(buffer_,other.buffer_,buffer_size * sizeof(output_char));
         }
     }
     

--- a/include/boost/nowide/system.hpp
+++ b/include/boost/nowide/system.hpp
@@ -8,15 +8,14 @@
 #ifndef BOOST_NOWIDE_CSTDLIB_HPP
 #define BOOST_NOWIDE_CSTDLIB_HPP
 
-#include <stdlib.h>
-#include <errno.h>
+#include <cstdlib>
 #include <boost/nowide/stackstring.hpp>
 namespace boost {
 namespace nowide {
 
 #if !defined(BOOST_WINDOWS) && !defined(BOOST_NOWIDE_DOXYGEN)
 
-using ::system;
+using std::system;
 
 #else // Windows
 

--- a/include/boost/nowide/windows.hpp
+++ b/include/boost/nowide/windows.hpp
@@ -8,8 +8,6 @@
 #ifndef BOOST_NOWIDE_WINDOWS_HPP_INCLUDED
 #define BOOST_NOWIDE_WINDOWS_HPP_INCLUDED
 
-#include <stddef.h>
-
 #ifdef BOOST_NOWIDE_USE_WINDOWS_H
 #include <windows.h>
 #else

--- a/src/iostream.cpp
+++ b/src/iostream.cpp
@@ -8,7 +8,7 @@
 #define BOOST_NOWIDE_SOURCE
 #include <boost/nowide/iostream.hpp>
 #include <boost/nowide/convert.hpp>
-#include <stdio.h>
+#include <cstring>
 #include <vector>
 
 #ifdef BOOST_WINDOWS
@@ -44,7 +44,7 @@ namespace details {
     protected:
         int sync()
         {
-            return overflow(EOF);
+            return overflow(traits_type::eof());
         }
         int overflow(int c)
         {
@@ -56,11 +56,11 @@ namespace details {
             if(n > 0 && (r=write(pbase(),n)) < 0)
                     return -1;
             if(r < n) {
-                memmove(pbase(),pbase() + r,n-r);
+                std::memmove(pbase(),pbase() + r,n-r);
             }
             setp(buffer_, buffer_ + buffer_size);
             pbump(n-r);
-            if(c!=EOF)
+            if(c!=traits_type::eof())
                 sputc(c);
             return 0;
         }
@@ -105,8 +105,8 @@ namespace details {
     protected:
         int pbackfail(int c)
         {
-            if(c==EOF)
-                return EOF;
+            if(c==traits_type::eof())
+                return traits_type::eof();
             
             if(gptr()!=eback()) {
                 gbump(-1);
@@ -147,7 +147,7 @@ namespace details {
             size_t n = read();
             setg(buffer_,buffer_,buffer_+n);
             if(n == 0)
-                return EOF;
+                return traits_type::eof();
             return std::char_traits<char>::to_int_type(*gptr());
         }
         
@@ -177,7 +177,7 @@ namespace details {
             
             
             if(c==uf::incomplete) {
-                memmove(b,e-wsize_,sizeof(wchar_t)*wsize_);
+                std::memmove(b,e-wsize_,sizeof(wchar_t)*wsize_);
             }
             
             return out - buffer_;

--- a/standalone/scoped_ptr.hpp
+++ b/standalone/scoped_ptr.hpp
@@ -12,7 +12,7 @@
 //  http://www.boost.org/libs/smart_ptr/scoped_ptr.htm
 //
 
-#include <assert.h>
+#include <cassert>
 
 namespace nowide
 {

--- a/standalone/utf.hpp
+++ b/standalone/utf.hpp
@@ -19,7 +19,7 @@ namespace utf {
 }
 }
 #else
-#include <stdint.h>
+#include <cstdint>
 #endif
 
 namespace nowide {

--- a/test/test_codecvt.cpp
+++ b/test/test_codecvt.cpp
@@ -13,8 +13,7 @@
 #include <vector>
 #include <iostream>
 #include <iomanip>
-#include <string.h>
-#include <memory.h>
+#include <cstring>
 #include "test.hpp"
 #include "test_sets.hpp"
 
@@ -51,8 +50,8 @@ typedef std::codecvt<wchar_t,char,std::mbstate_t> cvt_type;
 void test_codecvt_in_n_m(cvt_type const &cvt,int n,int m)
 {
     wchar_t const *wptr = wide_name;
-    int wlen = wcslen(wide_name);
-    int u8len = strlen(utf8_name);
+    int wlen = std::wcslen(wide_name);
+    int u8len = std::strlen(utf8_name);
     char const *from = utf8_name;
     char const *end = from;
     char const *real_end = utf8_name + u8len;
@@ -77,7 +76,7 @@ void test_codecvt_in_n_m(cvt_type const &cvt,int n,int m)
 
         int count = cvt.length(mb2,from,end,to_end - to);
         #ifndef BOOST_NOWIDE_DO_LENGTH_MBSTATE_CONST
-        TEST(memcmp(&mb,&mb2,sizeof(mb))==0);
+        TEST(std::memcmp(&mb,&mb2,sizeof(mb))==0);
         if(count != from_next - from) {
             std::cout << count << " " << from_next - from << std::endl;
         }
@@ -110,8 +109,8 @@ void test_codecvt_in_n_m(cvt_type const &cvt,int n,int m)
 void test_codecvt_out_n_m(cvt_type const &cvt,int n,int m)
 {
     char const *nptr = utf8_name;
-    int wlen = wcslen(wide_name);
-    int u8len = strlen(utf8_name);
+    int wlen = std::wcslen(wide_name);
+    int u8len = std::strlen(utf8_name);
 
     std::mbstate_t mb=std::mbstate_t();
 
@@ -167,8 +166,8 @@ void test_codecvt_conv()
 
     cvt_type const &cvt = std::use_facet<cvt_type>(l);
 
-    for(int i=1;i<=(int)strlen(utf8_name)+1;i++) {
-        for(int j=1;j<=(int)wcslen(wide_name)+1;j++) {
+    for(int i=1;i<=(int)std::strlen(utf8_name)+1;i++) {
+        for(int j=1;j<=(int)std::wcslen(wide_name)+1;j++) {
             try {
                 test_codecvt_in_n_m(cvt,i,j);
                 test_codecvt_out_n_m(cvt,i,j);
@@ -199,7 +198,7 @@ void test_codecvt_err()
         {
             std::mbstate_t mb=std::mbstate_t();
             char const *from=err_utf;
-            char const *from_end = from + strlen(from);
+            char const *from_end = from + std::strlen(from);
             char const *from_next = from;
             to_next = to;
             TEST(cvt.in(mb,from,from_end,from_next,to,to_end,to_next)==cvt_type::ok);
@@ -224,12 +223,12 @@ void test_codecvt_err()
         {
             std::mbstate_t mb=std::mbstate_t();
             wchar_t const *from=err_utf;
-            wchar_t const *from_end = from + wcslen(from);
+            wchar_t const *from_end = from + std::wcslen(from);
             wchar_t const *from_next = from;
             TEST(cvt.out(mb,from,from_end,from_next,to,to_end,to_next)==cvt_type::ok);
             TEST(from_next == from+2);
             TEST(to_next == to + 4);
-            TEST(memcmp(to,"1\xEF\xBF\xBD",4)==0);
+            TEST(std::memcmp(to,"1\xEF\xBF\xBD",4)==0);
         }
     }    
     

--- a/test/test_stdio.cpp
+++ b/test/test_stdio.cpp
@@ -13,7 +13,7 @@
 #include <boost/nowide/cstdio.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <iostream>
-#include <string.h>
+#include <cstring>
 
 #include "test.hpp"
 
@@ -38,7 +38,7 @@ int main()
         TEST((f=boost::nowide::fopen(example.c_str(),"r"))!=0);
         char buf[16];
         TEST(std::fgets(buf,16,f)!=0);
-        TEST(strcmp(buf,"test\n")==0);
+        TEST(std::strcmp(buf,"test\n")==0);
         TEST((f=boost::nowide::freopen(example.c_str(),"r+",f))!=0);
         std::fclose(f);
         f=0;

--- a/test/test_system.cpp
+++ b/test/test_system.cpp
@@ -10,7 +10,6 @@
 #include <boost/nowide/args.hpp>
 #include <boost/nowide/cenv.hpp>
 #include <iostream>
-#include <stdio.h>
 
 #include "test.hpp"
 


### PR DESCRIPTION
Supersedes https://github.com/boostorg/nowide/pull/40

While technically for e.g. `_wfopen` one needs `stdio.h` all compilers/stdlibs having this extension also have it when including `<cstdio>`. So use the C++ headers and the C++ functions to be consistent