### PR TITLE
Reduce number of Linux jobs run on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,53 @@ jobs:
     - env: BOGUS_JOB=true
 
   include:
-    - compiler: g++
-      env: CXXSTD=03,11
-
-    - compiler: g++-4.4
+    - stage: essential
+      compiler: g++-4.4
       env: CXXSTD=98,0x
       addons:
         apt:
           packages: [g++-4.4]
           sources: [ubuntu-toolchain-r-test]
+
+    - compiler: g++-9
+      env: UBSAN=1 CXXSTD=03,11,14,17,2a UBSAN_OPTIONS=print_stacktrace=1 LINKFLAGS=-fuse-ld=gold
+      addons:
+        apt:
+          packages: [g++-9]
+          sources: [ubuntu-toolchain-r-test]
+
+    - dist: trusty
+      compiler: /usr/bin/clang++
+      env: CXXSTD=03,11
+      addons:
+        apt:
+          packages: [clang-3.3]
+
+    - compiler: clang++-9
+      env: UBSAN=1 CXXSTD=03,11,14,17,2a UBSAN_OPTIONS=print_stacktrace=1 VISIBILITY=global
+      addons:
+        apt:
+          packages: [clang-9]
+          sources:
+            - ubuntu-toolchain-r-test
+            - sourceline: 'deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+
+    - dist: trusty
+      compiler: clang++-libc++
+      env: UBSAN=1 CXXSTD=03,11,14 UBSAN_OPTIONS=print_stacktrace=1
+      addons:
+        apt:
+          packages: [libc++-dev]
+
+    - os: osx
+      compiler: clang++
+      env: UBSAN=1 CXXSTD=03,11,14,1z UBSAN_OPTIONS=print_stacktrace=1
+
+    # Additional compiler versions tested for completenes
+    - stage: additional
+      compiler: g++
+      env: CXXSTD=03,11
 
     - compiler: g++-4.6
       env: CXXSTD=03,0x
@@ -94,22 +132,8 @@ jobs:
           packages: [g++-9]
           sources: [ubuntu-toolchain-r-test]
 
-    - compiler: g++-9
-      env: UBSAN=1 CXXSTD=03,11,14,17,2a UBSAN_OPTIONS=print_stacktrace=1 LINKFLAGS=-fuse-ld=gold
-      addons:
-        apt:
-          packages: [g++-9]
-          sources: [ubuntu-toolchain-r-test]
-
     - compiler: clang++
       env: CXXSTD=03,11
-
-    - dist: trusty
-      compiler: /usr/bin/clang++
-      env: CXXSTD=03,11
-      addons:
-        apt:
-          packages: [clang-3.3]
 
     - dist: trusty
       compiler: /usr/bin/clang++
@@ -202,24 +226,8 @@ jobs:
             - sourceline: 'deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
 
-    - compiler: clang++-8
-      env: UBSAN=1 CXXSTD=03,11,14,17,2a UBSAN_OPTIONS=print_stacktrace=1 VISIBILITY=global
-      addons:
-        apt:
-          packages: [clang-8]
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-xenial-8
-
     - compiler: clang++-libc++
       env: CXXSTD=03,11,14
-      addons:
-        apt:
-          packages: [libc++-dev]
-
-    - dist: trusty
-      compiler: clang++-libc++
-      env: UBSAN=1 CXXSTD=03,11,14 UBSAN_OPTIONS=print_stacktrace=1
       addons:
         apt:
           packages: [libc++-dev]
@@ -228,9 +236,10 @@ jobs:
       compiler: clang++
       env: CXXSTD=03,11,14,1z
 
-    - os: osx
-      compiler: clang++
-      env: UBSAN=1 CXXSTD=03,11,14,1z UBSAN_OPTIONS=print_stacktrace=1
+stages:
+  - essential
+  - name: additional
+    if: type != "pull_request"
 
 install:
   - BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
 
 language: cpp
-
-sudo: false
-
+os: linux
 dist: xenial
 
 branches:
@@ -18,297 +16,221 @@ env:
   matrix:
     - BOGUS_JOB=true
 
-matrix:
-
+jobs:
   exclude:
     - env: BOGUS_JOB=true
 
   include:
-    - os: linux
-      compiler: g++
-      env: TOOLSET=gcc COMPILER=g++ CXXSTD=03,11
+    - compiler: g++
+      env: CXXSTD=03,11
 
-    - os: linux
-      compiler: g++-4.4
-      env: TOOLSET=gcc COMPILER=g++-4.4 CXXSTD=98,0x
+    - compiler: g++-4.4
+      env: CXXSTD=98,0x
       addons:
         apt:
-          packages:
-            - g++-4.4
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [g++-4.4]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: g++-4.6
-      env: TOOLSET=gcc COMPILER=g++-4.6 CXXSTD=03,0x
+    - compiler: g++-4.6
+      env: CXXSTD=03,0x
       addons:
         apt:
-          packages:
-            - g++-4.6
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [g++-4.6]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: g++-4.7
-      env: TOOLSET=gcc COMPILER=g++-4.7 CXXSTD=03,11
+    - compiler: g++-4.7
+      env: CXXSTD=03,11
       addons:
         apt:
-          packages:
-            - g++-4.7
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [g++-4.7]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: g++-4.8
-      env: TOOLSET=gcc COMPILER=g++-4.8 CXXSTD=03,11
+    - compiler: g++-4.8
+      env: CXXSTD=03,11
       addons:
         apt:
-          packages:
-            - g++-4.8
-          sources:
-            - ubuntu-toolchain-r-test
-    - os: linux
-      compiler: g++-4.9
-      env: TOOLSET=gcc COMPILER=g++-4.9 CXXSTD=03,11
+          packages: [g++-4.8]
+          sources: [ubuntu-toolchain-r-test]
+
+    - compiler: g++-4.9
+      env: CXXSTD=03,11
       addons:
         apt:
-          packages:
-            - g++-4.9
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [g++-4.9]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: g++-5
-      env: TOOLSET=gcc COMPILER=g++-5 CXXSTD=03,11,14,1z
+    - compiler: g++-5
+      env: CXXSTD=03,11,14,1z
       addons:
         apt:
-          packages:
-            - g++-5
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [g++-5]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: g++-6
-      env: TOOLSET=gcc COMPILER=g++-6 CXXSTD=03,11,14,1z
+    - compiler: g++-6
+      env: CXXSTD=03,11,14,1z
       addons:
         apt:
-          packages:
-            - g++-6
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [g++-6]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: g++-7
-      env: TOOLSET=gcc COMPILER=g++-7 CXXSTD=03,11,14,17
+    - compiler: g++-7
+      env: CXXSTD=03,11,14,17
       addons:
         apt:
-          packages:
-            - g++-7
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [g++-7]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: g++-8
-      env: TOOLSET=gcc COMPILER=g++-8 CXXSTD=03,11,14,17,2a
+    - compiler: g++-8
+      env: CXXSTD=03,11,14,17,2a
       addons:
         apt:
-          packages:
-            - g++-8
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [g++-8]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: g++-9
-      env: TOOLSET=gcc COMPILER=g++-9 CXXSTD=03,11,14,17,2a
+    - compiler: g++-9
+      env: CXXSTD=03,11,14,17,2a
       addons:
         apt:
-          packages:
-            - g++-9
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [g++-9]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: g++-9
-      env: UBSAN=1 TOOLSET=gcc COMPILER=g++-9 CXXSTD=03,11,14,17,2a UBSAN_OPTIONS=print_stacktrace=1 LINKFLAGS=-fuse-ld=gold
+    - compiler: g++-9
+      env: UBSAN=1 CXXSTD=03,11,14,17,2a UBSAN_OPTIONS=print_stacktrace=1 LINKFLAGS=-fuse-ld=gold
       addons:
         apt:
-          packages:
-            - g++-9
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [g++-9]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: clang++
-      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11
+    - compiler: clang++
+      env: CXXSTD=03,11
 
-    - os: linux
-      dist: trusty
+    - dist: trusty
       compiler: /usr/bin/clang++
-      env: TOOLSET=clang COMPILER=/usr/bin/clang++ CXXSTD=03,11
+      env: CXXSTD=03,11
       addons:
         apt:
-          packages:
-            - clang-3.3
+          packages: [clang-3.3]
 
-    - os: linux
-      dist: trusty
+    - dist: trusty
       compiler: /usr/bin/clang++
-      env: TOOLSET=clang COMPILER=/usr/bin/clang++ CXXSTD=03,11
+      env: CXXSTD=03,11
       addons:
         apt:
-          packages:
-            - clang-3.4
+          packages: [clang-3.4]
 
-    - os: linux
-      compiler: clang++-3.5
-      env: TOOLSET=clang COMPILER=clang++-3.5 CXXSTD=03,11
+    - compiler: clang++-3.5
+      env: CXXSTD=03,11
       addons:
         apt:
-          packages:
-            - clang-3.5
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [clang-3.5]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: clang++-3.6
-      env: TOOLSET=clang COMPILER=clang++-3.6 CXXSTD=03,11,14,1z
+    - compiler: clang++-3.6
+      env: CXXSTD=03,11,14,1z
       addons:
         apt:
-          packages:
-            - clang-3.6
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [clang-3.6]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: clang++-3.7
-      env: TOOLSET=clang COMPILER=clang++-3.7 CXXSTD=03,11,14,1z
+    - compiler: clang++-3.7
+      env: CXXSTD=03,11,14,1z
       addons:
         apt:
-          packages:
-            - clang-3.7
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [clang-3.7]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: clang++-3.8
-      env: TOOLSET=clang COMPILER=clang++-3.8 CXXSTD=03,11,14,1z
+    - compiler: clang++-3.8
+      env: CXXSTD=03,11,14,1z
       addons:
         apt:
-          packages:
-            - clang-3.8
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [clang-3.8]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: clang++-3.9
-      env: TOOLSET=clang COMPILER=clang++-3.9 CXXSTD=03,11,14,1z
+    - compiler: clang++-3.9
+      env: CXXSTD=03,11,14,1z
       addons:
         apt:
-          packages:
-            - clang-3.9
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [clang-3.9]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: clang++-4.0
-      env: TOOLSET=clang COMPILER=clang++-4.0 CXXSTD=03,11,14,1z
+    - compiler: clang++-4.0
+      env: CXXSTD=03,11,14,1z
       addons:
         apt:
-          packages:
-            - clang-4.0
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [clang-4.0]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: clang++-5.0
-      env: TOOLSET=clang COMPILER=clang++-5.0 CXXSTD=03,11,14,1z
+    - compiler: clang++-5.0
+      env: CXXSTD=03,11,14,1z
       addons:
         apt:
-          packages:
-            - clang-5.0
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [clang-5.0]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: clang++-6.0
-      env: TOOLSET=clang COMPILER=clang++-6.0 CXXSTD=03,11,14,17
+    - compiler: clang++-6.0
+      env: CXXSTD=03,11,14,17
       addons:
         apt:
-          packages:
-            - clang-6.0
-          sources:
-            - ubuntu-toolchain-r-test
+          packages: [clang-6.0]
+          sources: [ubuntu-toolchain-r-test]
 
-    - os: linux
-      compiler: clang++-7
-      env: TOOLSET=clang COMPILER=clang++-7 CXXSTD=03,11,14,17,2a
+    - compiler: clang++-7
+      env: CXXSTD=03,11,14,17,2a
       addons:
         apt:
-          packages:
-            - clang-7
+          packages: [clang-7]
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-xenial-7
 
-    - os: linux
-      compiler: clang++-8
-      env: TOOLSET=clang COMPILER=clang++-8 CXXSTD=03,11,14,17,2a
+    - compiler: clang++-8
+      env: CXXSTD=03,11,14,17,2a
       addons:
         apt:
-          packages:
-            - clang-8
+          packages: [clang-8]
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-xenial-8
 
-    - os: linux
-      dist: xenial
-      compiler: clang++-9
-      env: TOOLSET=clang COMPILER=clang++-9 CXXSTD=03,11,14,17,2a
+    - compiler: clang++-9
+      env: CXXSTD=03,11,14,17,2a
       addons:
         apt:
-          packages:
-            - clang-9
+          packages: [clang-9]
           sources:
             - ubuntu-toolchain-r-test
             - sourceline: 'deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
 
-    - os: linux
-      compiler: clang++-8
-      env: UBSAN=1 TOOLSET=clang COMPILER=clang++-8 CXXSTD=03,11,14,17,2a UBSAN_OPTIONS=print_stacktrace=1 VISIBILITY=global
+    - compiler: clang++-8
+      env: UBSAN=1 CXXSTD=03,11,14,17,2a UBSAN_OPTIONS=print_stacktrace=1 VISIBILITY=global
       addons:
         apt:
-          packages:
-            - clang-8
+          packages: [clang-8]
           sources:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-xenial-8
 
-    - os: linux
-      compiler: clang++-libc++
-      env: TOOLSET=clang COMPILER=clang++-libc++ CXXSTD=03,11,14
+    - compiler: clang++-libc++
+      env: CXXSTD=03,11,14
       addons:
         apt:
-          packages:
-            - libc++-dev
+          packages: [libc++-dev]
 
-    - os: linux
-      dist: trusty
+    - dist: trusty
       compiler: clang++-libc++
-      env: UBSAN=1 TOOLSET=clang COMPILER=clang++-libc++ CXXSTD=03,11,14 UBSAN_OPTIONS=print_stacktrace=1
+      env: UBSAN=1 CXXSTD=03,11,14 UBSAN_OPTIONS=print_stacktrace=1
       addons:
         apt:
-          packages:
-            - libc++-dev
+          packages: [libc++-dev]
 
     - os: osx
       compiler: clang++
-      env: TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z
+      env: CXXSTD=03,11,14,1z
 
     - os: osx
       compiler: clang++
-      env: UBSAN=1 TOOLSET=clang COMPILER=clang++ CXXSTD=03,11,14,1z UBSAN_OPTIONS=print_stacktrace=1
+      env: UBSAN=1 CXXSTD=03,11,14,1z UBSAN_OPTIONS=print_stacktrace=1
 
 install:
   - BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true
@@ -323,10 +245,16 @@ install:
   - ./b2 headers
 
 script:
-  - |-
-    echo "using $TOOLSET : : $COMPILER ;" > ~/user-config.jam
+  - |
+    if [[ "$TRAVIS_COMPILER" =~ clang\+\+ ]]; then
+        TOOLSET=clang
+    elif [[ "$TRAVIS_COMPILER" =~ g\+\+ ]]; then
+        TOOLSET=gcc
+    else
+        false
+    fi
+  -  which $TRAVIS_COMPILER
+  -  $TRAVIS_COMPILER --version
+  - |
+    echo "using $TOOLSET : : $TRAVIS_COMPILER ;" > ~/user-config.jam
   - ./b2 -j3 libs/nowide/test toolset=$TOOLSET cxxstd=$CXXSTD variant=debug,release ${UBSAN:+cxxflags=-fsanitize=undefined cxxflags=-fno-sanitize-recover=undefined linkflags=-fsanitize=undefined define=UBSAN=1 debug-symbols=on} ${LINKFLAGS:+linkflags=$LINKFLAGS} ${VISIBILITY:+visibility=$VISIBILITY}
-
-notifications:
-  email:
-    on_success: always


### PR DESCRIPTION
The library is mostly for windows, so there isn't much to test on Linux
Reduce to oldest and most recent compilers
But still test all on pushes to eventually detect compiler version specific issues

Fixes #50