### PR TITLE
Fix codecvt and improve conversion tests

### DIFF
--- a/include/boost/nowide/utf8_codecvt.hpp
+++ b/include/boost/nowide/utf8_codecvt.hpp
@@ -282,7 +282,7 @@ namespace nowide {
             }
             from_next = from;
             to_next = to;
-            if(r == std::codecvt_base::ok && from != from_end)
+            if(r == std::codecvt_base::ok && (from != from_end || state != 0))
                 r = std::codecvt_base::partial;
             detail::write_state(std_state, state);
             return r;

--- a/test/test_sets.hpp
+++ b/test/test_sets.hpp
@@ -8,7 +8,7 @@
 #ifndef BOOST_NOWIDE_TEST_SETS_HPP_INCLUDED
 #define BOOST_NOWIDE_TEST_SETS_HPP_INCLUDED
 
-#include <boost/config.hpp>
+#include <boost/nowide/config.hpp>
 #include <iostream>
 #include <string>
 
@@ -28,67 +28,102 @@ struct wide_to_utf8
 #pragma warning(disable : 4428) // universal-character-name encountered in source
 #endif
 
-utf8_to_wide n2w_tests[] = {{"\xf0\x9d\x92\x9e-\xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82-\xE3\x82\x84\xE3\x81\x82.txt",
-                             L"\U0001D49E-\u043F\u0440\u0438\u0432\u0435\u0442-\u3084\u3042.txt"},
-                            {"\xFF\xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82", L"\uFFFD\u043F\u0440\u0438\u0432\u0435\u0442"},
-                            {"\xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82\xFF", L"\u043F\u0440\u0438\u0432\u0435\u0442\uFFFD"},
-                            {"\xE3\x82\xFF\xE3\x81\x82", L"\ufffd\u3042"},
-                            {"\xE3\xFF\x84\xE3\x81\x82", L"\ufffd\ufffd\u3042"}};
+const std::wstring wreplacement_str(1, wchar_t(BOOST_NOWIDE_REPLACEMENT_CHARACTER));
 
-wide_to_utf8 w2n_tests_utf16[] = {
-  {
-    L"\U0001D49E-\u043F\u0440\u0438\u0432\u0435\u0442-\u3084\u3042.txt",
-    "\xf0\x9d\x92\x9e-\xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82-\xE3\x82\x84\xE3\x81\x82.txt",
-  },
+// clang-format off
+const utf8_to_wide roundtrip_tests[] = {
+    {"", L""},
+    {"\xf0\x9d\x92\x9e-\xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82-\xE3\x82\x84\xE3\x81\x82.txt",
+    L"\U0001D49E-\u043F\u0440\u0438\u0432\u0435\u0442-\u3084\u3042.txt"},
+    {"\xd7\xa9-\xd0\xbc-\xce\xbd.txt",
+    L"\u05e9-\u043c-\u03bd.txt"},
+    {"\xd7\xa9\xd7\x9c\xd7\x95\xd7\x9d",
+    L"\u05e9\u05dc\u05d5\u05dd"},
+};
+
+const utf8_to_wide invalid_utf8_tests[] = {
+    {"\xFF\xFF", L"\ufffd\ufffd"},
+    {"\xd7\xa9\xFF", L"\u05e9\ufffd"},
+    {"\xd7", L"\ufffd"},
+    {"\xFF\xd7\xa9", L"\ufffd\u05e9"},
+    {"\xFF\xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82", L"\uFFFD\u043F\u0440\u0438\u0432\u0435\u0442"},
+    {"\xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82\xFF", L"\u043F\u0440\u0438\u0432\u0435\u0442\uFFFD"},
+    {"\xE3\x82\xFF\xE3\x81\x82", L"\ufffd\u3042"},
+    {"\xE3\xFF\x84\xE3\x81\x82", L"\ufffd\ufffd\u3042"},
+};
+
+const wide_to_utf8 invalid_wide_tests[] = {
+  {L"\xDC01\x05e9", "\xEF\xBF\xBD\xd7\xa9"},
+  {L"\x05e9\xD800", "\xd7\xa9\xEF\xBF\xBD"},
+  {L"\xDC00\x20\u043F\u0440\u0438\u0432\u0435\u0442-\u3084\u3042",
+   "\xEF\xBF\xBD \xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82-\xE3\x82\x84\xE3\x81\x82"},
+  {L"\u3084\u3042\xDC00\x20\u043F\u0440\u0438\u0432\u0435\u0442-\u3084\u3042",
+   "\xE3\x82\x84\xE3\x81\x82\xEF\xBF\xBD \xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82-\xE3\x82\x84\xE3\x81\x82"},
+};
+
+
+const wide_to_utf8 invalid_utf16_tests[] = {
   {L"\xD800\x20\u043F\u0440\u0438\u0432\u0435\u0442-\u3084\u3042",
    "\xEF\xBF\xBD\xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82-\xE3\x82\x84\xE3\x81\x82"},
-  {L"\xDC00\x20\u043F\u0440\u0438\u0432\u0435\u0442-\u3084\u3042",
-   "\xEF\xBF\xBD \xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82-\xE3\x82\x84\xE3\x81\x82"},
   {L"\u3084\u3042\xD800\x20\u043F\u0440\u0438\u0432\u0435\u0442-\u3084\u3042",
    "\xE3\x82\x84\xE3\x81\x82\xEF\xBF\xBD\xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82-\xE3\x82\x84\xE3\x81\x82"},
-  {L"\u3084\u3042\xDC00\x20\u043F\u0440\u0438\u0432\u0435\u0442-\u3084\u3042",
-   "\xE3\x82\x84\xE3\x81\x82\xEF\xBF\xBD \xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82-\xE3\x82\x84\xE3\x81\x82"}};
+};
 
-wide_to_utf8 w2n_tests_utf32[] = {
-  {
-    L"\U0001D49E-\u043F\u0440\u0438\u0432\u0435\u0442-\u3084\u3042.txt",
-    "\xf0\x9d\x92\x9e-\xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82-\xE3\x82\x84\xE3\x81\x82.txt",
-  },
+const wide_to_utf8 invalid_utf32_tests[] = {
   {L"\xD800\x20\u043F\u0440\u0438\u0432\u0435\u0442-\u3084\u3042",
-   "\xEF\xBF\xBD \xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82-\xE3\x82\x84\xE3\x81\x82"},
-  {L"\xDC00\x20\u043F\u0440\u0438\u0432\u0435\u0442-\u3084\u3042",
    "\xEF\xBF\xBD \xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82-\xE3\x82\x84\xE3\x81\x82"},
   {L"\u3084\u3042\xD800\x20\u043F\u0440\u0438\u0432\u0435\u0442-\u3084\u3042",
    "\xE3\x82\x84\xE3\x81\x82\xEF\xBF\xBD \xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82-\xE3\x82\x84\xE3\x81\x82"},
-  {L"\u3084\u3042\xDC00\x20\u043F\u0440\u0438\u0432\u0435\u0442-\u3084\u3042",
-   "\xE3\x82\x84\xE3\x81\x82\xEF\xBF\xBD \xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82-\xE3\x82\x84\xE3\x81\x82"}};
+};
+
+// clang-format on
 
 #ifdef BOOST_MSVC
 #pragma warning(push)
 #pragma warning(disable : 4127) // Constant expression detected
 #endif
 
+template<typename T, size_t N>
+size_t array_size(const T (&)[N])
+{
+    return N;
+}
+
 void run_all(std::wstring (*to_wide)(const std::string&), std::string (*to_narrow)(const std::wstring&))
 {
-    for(size_t i = 0; i < sizeof(n2w_tests) / sizeof(n2w_tests[0]); i++)
+    for(size_t i = 0; i < array_size(roundtrip_tests); i++)
     {
-        std::cout << "  N2W  " << i << std::endl;
-        TEST(to_wide(n2w_tests[i].utf8) == n2w_tests[i].wide);
+        std::cout << "  Roundtrip  " << i << std::endl;
+        TEST(roundtrip_tests[i].utf8 == to_narrow(roundtrip_tests[i].wide));
+        TEST(to_wide(roundtrip_tests[i].utf8) == roundtrip_tests[i].wide);
     }
+
+    for(size_t i = 0; i < array_size(invalid_utf8_tests); i++)
+    {
+        std::cout << "  Invalid UTF8  " << i << std::endl;
+        TEST(to_wide(invalid_utf8_tests[i].utf8) == invalid_utf8_tests[i].wide);
+    }
+
+    for(size_t i = 0; i < array_size(invalid_wide_tests); i++)
+    {
+        std::cout << "  Invalid Wide  " << i << std::endl;
+        TEST(to_narrow(invalid_wide_tests[i].wide) == invalid_wide_tests[i].utf8);
+    }
+
     size_t total = 0;
     const wide_to_utf8* ptr = 0;
     if(sizeof(wchar_t) == 2)
     {
-        ptr = w2n_tests_utf16;
-        total = sizeof(w2n_tests_utf16) / sizeof(w2n_tests_utf16[0]);
+        ptr = invalid_utf16_tests;
+        total = array_size(invalid_utf16_tests);
     } else
     {
-        ptr = w2n_tests_utf32;
-        total = sizeof(w2n_tests_utf32) / sizeof(w2n_tests_utf32[0]);
+        ptr = invalid_utf32_tests;
+        total = array_size(invalid_utf32_tests);
     }
     for(size_t i = 0; i < total; i++)
     {
-        std::cout << "  W2N  " << i << std::endl;
+        std::cout << "  Invalid UTF16/32  " << i << std::endl;
         TEST(to_narrow(ptr[i].wide) == ptr[i].utf8);
     }
 }

--- a/test/test_stackstring.cpp
+++ b/test/test_stackstring.cpp
@@ -27,12 +27,24 @@ std::string stackstring_to_narrow(const std::wstring& s)
     return ss.get();
 }
 
+std::wstring heap_stackstring_to_wide(const std::string& s)
+{
+    const boost::nowide::basic_stackstring<wchar_t, char, 1> ss(s.c_str());
+    return ss.get();
+}
+
+std::string heap_stackstring_to_narrow(const std::wstring& s)
+{
+    const boost::nowide::basic_stackstring<char, wchar_t, 1> ss(s.c_str());
+    return ss.get();
+}
+
 int main()
 {
     try
     {
         std::string hello = "\xd7\xa9\xd7\x9c\xd7\x95\xd7\x9d";
-        std::wstring whello = L"\u05e9\u05dc\u05d5\u05dd";
+        std::wstring whello = boost::nowide::widen(hello);
         const wchar_t* wempty = L"";
 
         {
@@ -76,6 +88,7 @@ int main()
             TEST(s2.get() == std::string());
         }
         {
+            // Will be put on heap
             TEST(whello.size() >= 3);
             boost::nowide::basic_stackstring<wchar_t, char, 3> sw;
             TEST(sw.convert(hello.c_str()));
@@ -84,6 +97,7 @@ int main()
             TEST(sw.get() == whello);
         }
         {
+            // Will be put on stack
             TEST(whello.size() < 5);
             boost::nowide::basic_stackstring<wchar_t, char, 5> sw;
             TEST(sw.convert(hello.c_str()));
@@ -92,6 +106,7 @@ int main()
             TEST(sw.get() == whello);
         }
         {
+            // Will be put on heap
             TEST(hello.size() >= 5);
             boost::nowide::basic_stackstring<char, wchar_t, 5> sw;
             TEST(sw.convert(whello.c_str()));
@@ -100,6 +115,7 @@ int main()
             TEST(sw.get() == hello);
         }
         {
+            // Will be put on stack
             TEST(hello.size() < 10);
             boost::nowide::basic_stackstring<char, wchar_t, 10> sw;
             TEST(sw.convert(whello.c_str()));
@@ -168,8 +184,10 @@ int main()
             TEST(stack.get() == stackVal);
             TEST(heap.get() == heapVal);
         }
-        std::cout << "- Substitutions" << std::endl;
+        std::cout << "- Stackstring" << std::endl;
         run_all(stackstring_to_wide, stackstring_to_narrow);
+        std::cout << "- Heap Stackstring" << std::endl;
+        run_all(heap_stackstring_to_wide, heap_stackstring_to_narrow);
     } catch(const std::exception& e)
     {
         std::cerr << "Failed :" << e.what() << std::endl;


### PR DESCRIPTION
Converting an UTF-16 encoded string to UTF-8 with utf8_codecvt leads wrongly to a `ok` return value, but `partial` would be correct.