### PR TITLE
Make the behavior of the class `args` clearer in doc

### DIFF
--- a/doc/main.dox
+++ b/doc/main.dox
@@ -222,9 +222,9 @@ This very simple and straightforward approach helps writing Unicode aware progra
 Watch the use of \c boost::nowide::args, \c boost::nowide::ifstream and \c boost::nowide::cerr/cout.
 On Non-Windows it does nothing, but on Windows the following happens:
 
-- \c boost::nowide::args uses the Windows API to retrieve UTF-16 arguments, converts them to UTF-8
-and replaces the original \c argv (and optionally \c env) to point to those, internally stored
-UTF-8 strings.
+- \c boost::nowide::args retrieves UTF-16 arguments from the Windows API, converts them to UTF-8,
+and temporarily covers the original \c argv (and optionally \c env) with point to those, internally stored
+UTF-8 strings, while its instance alive.
 - \c boost::nowide::ifstream converts the passed filename (which is now valid UTF-8) to UTF-16
 and calls the Windows Wide API to open the file stream which can then be used as usual.
 - Similarily \c boost::nowide::cerr and \c boost::nowide::cout use an underlying stream buffer

--- a/include/boost/nowide/args.hpp
+++ b/include/boost/nowide/args.hpp
@@ -33,14 +33,14 @@ namespace nowide {
 #else
 
     ///
-    /// \brief args is a class that fixes standard main() function arguments and changes them to UTF-8 under
-    /// Microsoft Windows.
+    /// \brief \c args is a class that temporarily covers standard main() function arguments encoded by an non-Unicode character set
+    /// and changes them to UTF-8 under Microsoft Windows while its instance alive.
     ///
     /// The class uses \c GetCommandLineW(), \c CommandLineToArgvW() and \c GetEnvironmentStringsW()
-    /// in order to obtain the information. It does not relate to actual values of argc,argv and env
+    /// in order to obtain Unicode-encoded values. It does not relate to actual values of argc,argv and env
     /// under Windows.
     ///
-    /// It restores the original values in its destructor
+    /// It restores the original values in its destructor (usually just before \c return statements in the function \c main).
     ///
     /// If any of the system calls fails, an exception of type std::runtime_error will be thrown
     /// and argc, argv, env remain unchanged.


### PR DESCRIPTION
The  documentation did not seem to be easy for me to understand what `boost::nowide::args` does with `argv`, one of arguments of `main`.
I reworded sentences explaining the behavior of `boost::no::wide::args` to make the following clearer:
- The instance of this class *hides* the original but legacy-encoded (`argc`,) `argv` (, and `env`) with UTF-8 encoded ones *only while it is alive.* (the most important)
- This class fetches the complete (Unicode) (`argc`,) `argv` (, and `env`) from the Windows API regardleass of `main`, and converts them to UTF-8 *by itself.*

I do not have any confidence in selecting words.  You can fix my words in the contents of this PR as you like without asking me.