### PR TITLE
Make Large File Support more portable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,13 +34,17 @@ endif()
 
 include(BoostAddOptions)
 include(BoostAddWarnings)
+include(CheckCXXSourceCompiles)
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   include(CTest)
 endif()
 
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/test/check_lfs_support.cpp lfsSource)
+check_cxx_source_compiles("${lfsSource}" BOOST_NOWIDE_HAS_LFS)
+
 # Using glob here is ok as it is only for headers
 file(GLOB_RECURSE headers include/*.hpp)
-add_library(boost_nowide src/cstdio.cpp src/cstdlib.cpp src/iostream.cpp ${headers})
+add_library(boost_nowide src/cstdio.cpp src/cstdlib.cpp src/filebuf.cpp src/iostream.cpp ${headers})
 add_library(Boost::nowide ALIAS boost_nowide)
 set_target_properties(boost_nowide PROPERTIES
     CXX_VISIBILITY_PRESET hidden
@@ -50,6 +54,9 @@ set_target_properties(boost_nowide PROPERTIES
 )
 if(BUILD_SHARED_LIBS)
   target_compile_definitions(boost_nowide PUBLIC BOOST_NOWIDE_DYN_LINK)
+endif()
+if(NOT BOOST_NOWIDE_HAS_LFS)
+  target_compile_definitions(boost_nowide PRIVATE BOOST_NOWIDE_NO_LFS)
 endif()
 target_compile_definitions(boost_nowide PUBLIC BOOST_NOWIDE_NO_LIB)
 target_include_directories(boost_nowide PUBLIC include)

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -16,6 +16,8 @@ local requirements =
 
 obj cxx11_moveable_fstreams : ../test/check_movable_fstreams.cpp ;
 explicit cxx11_moveable_fstreams ;
+obj lfs_support : ../test/check_lfs_support.cpp ;
+explicit lfs_support ;
 
 project boost/nowide
   : source-location ../src
@@ -26,11 +28,12 @@ project boost/nowide
       cxx11_rvalue_references
       cxx11_static_assert
     ]
-    [ check-target-builds cxx11_moveable_fstreams "std::fstream is moveable and swappable" : : <build>no ] 
+    [ check-target-builds cxx11_moveable_fstreams "std::fstream is moveable and swappable" : : <build>no ]
+    [ check-target-builds lfs_support "Has Large File Support" : : <define>BOOST_NOWIDE_NO_LFS ]
   : usage-requirements $(requirements)
   ;
 
-local SOURCES = cstdio cstdlib iostream ;
+local SOURCES = cstdio cstdlib filebuf iostream ;
 
 lib boost_nowide
   : $(SOURCES).cpp

--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -13,6 +13,7 @@
 \subsection changelog_11_0_0 Nowide 11.0.0
 
 - Require C++11 compatible compiler and stdlib
+- LFS: Add support for files > 2 GB where the underlying system supports it
 
 \subsection changelog_10_0_2 Nowide 10.0.2
 

--- a/include/boost/nowide/config.hpp
+++ b/include/boost/nowide/config.hpp
@@ -50,20 +50,6 @@
 
 //! @endcond
 
-#if defined(__MINGW64__)
-#define BOOST_NOWIDE_FTELL64 ftello64
-#define BOOST_NOWIDE_FSEEK64 fseeko64
-#elif defined(__APPLE__)
-#define BOOST_NOWIDE_FTELL64 ftello
-#define BOOST_NOWIDE_FSEEK64 fseeko
-#elif defined(_MSC_VER)
-#define BOOST_NOWIDE_FTELL64 _ftelli64
-#define BOOST_NOWIDE_FSEEK64 _fseeki64
-#else
-#define BOOST_NOWIDE_FTELL64 ftell
-#define BOOST_NOWIDE_FSEEK64 fseek
-#endif
-
 /// @def BOOST_NOWIDE_USE_WCHAR_OVERLOADS
 /// @brief Whether to use the wchar_t* overloads in fstream/filebuf
 /// Enabled on Windows and Cygwin as the latter may use wchar_t in filesystem::path

--- a/src/filebuf.cpp
+++ b/src/filebuf.cpp
@@ -1,0 +1,80 @@
+//
+//  Copyright (c) 2020 Alexander Grund
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#define BOOST_NOWIDE_SOURCE
+
+#ifdef BOOST_NOWIDE_NO_LFS
+#define BOOST_NOWIDE_FTELL ::ftell
+#define BOOST_NOWIDE_FSEEK ::fseek
+#define BOOST_NOWIDE_OFF_T long
+#elif defined(_WIN32) && !defined(__CYGWIN__)
+#define BOOST_NOWIDE_FTELL _ftelli64
+#define BOOST_NOWIDE_FSEEK _fseeki64
+#define BOOST_NOWIDE_OFF_T int64_t
+#else
+// IMPORTANT: Have these defines BEFORE any #includes
+//            and make sure changes by those macros don't leak into the public interface
+// Make LFS functions available
+#define _LARGEFILE_SOURCE
+// Make off_t 64 bits if the macro isn't set
+#ifndef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 64
+#endif
+
+#define BOOST_NOWIDE_FTELL ftello
+#define BOOST_NOWIDE_FSEEK fseeko
+#define BOOST_NOWIDE_OFF_T off_t
+#endif
+
+#include <boost/nowide/filebuf.hpp>
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <stdio.h>
+#include <type_traits>
+
+namespace boost {
+namespace nowide {
+    namespace detail {
+
+        template<typename T, typename U>
+        constexpr bool is_in_range(U value)
+        {
+            static_assert(std::is_signed<T>::value == std::is_signed<U>::value,
+                          "Mixed sign comparison can lead to problems below");
+            // coverity[result_independent_of_operands]
+            return value >= std::numeric_limits<T>::min() && value <= std::numeric_limits<T>::max();
+        }
+
+        template<typename T, typename U>
+        T cast_if_valid_or_minus_one(U value)
+        {
+            return is_in_range<T>(value) ? static_cast<T>(value) : T(-1);
+        }
+
+        std::streampos ftell(FILE* file)
+        {
+            const auto pos = BOOST_NOWIDE_FTELL(file);
+            // Note that this is used in seekoff for which the standard states:
+            // On success, it returns the new absolute position the internal position pointer points to after the call,
+            // if representable [...] [or] the function returns pos_type(off_type(-1)). Hence we do a range check first,
+            // then cast or return failure instead of silently truncating
+            return cast_if_valid_or_minus_one<std::streamoff>(pos);
+        }
+
+        int fseek(FILE* file, std::streamoff offset, int origin)
+        {
+            // Similar to above: If the value of offset can't fit inside target type
+            // don't silently truncate but fail right away
+            if(!is_in_range<BOOST_NOWIDE_OFF_T>(offset))
+                return -1;
+            return BOOST_NOWIDE_FSEEK(file, static_cast<BOOST_NOWIDE_OFF_T>(offset), origin);
+        }
+    } // namespace detail
+} // namespace nowide
+} // namespace boost

--- a/standalone/config.hpp
+++ b/standalone/config.hpp
@@ -19,20 +19,6 @@
 #define NOWIDE_MSVC _MSC_VER
 #endif
 
-#if defined(__MINGW64__)
-#define BOOST_NOWIDE_FTELL64 ftello64
-#define BOOST_NOWIDE_FSEEK64 fseeko64
-#elif defined(__APPLE__)
-#define BOOST_NOWIDE_FTELL64 ftello
-#define BOOST_NOWIDE_FSEEK64 fseeko
-#elif defined(_MSC_VER)
-#define BOOST_NOWIDE_FTELL64 _ftelli64
-#define BOOST_NOWIDE_FSEEK64 _fseeki64
-#else
-#define BOOST_NOWIDE_FTELL64 ftell
-#define BOOST_NOWIDE_FSEEK64 fseek
-#endif
-
 #ifdef __GNUC__
 #define BOOST_SYMBOL_VISIBLE __attribute__((__visibility__("default")))
 #endif

--- a/test/check_lfs_support.cpp
+++ b/test/check_lfs_support.cpp
@@ -1,0 +1,26 @@
+//
+//  Copyright (c) 2020 Alexander Grund
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE or copy at http://www.boost.org/LICENSE.txt)
+//
+
+#define _LARGEFILE_SOURCE
+#include <stdio.h>
+
+void check(FILE* f)
+{
+#if defined(_WIN32) && !defined(__CYGWIN__)
+    (void)_fseeki64(f, 0, SEEK_CUR);
+    (void)_ftelli64(f);
+#else
+    // Check that those functions and off_t are available
+    (void)fseeko(f, off_t(0), SEEK_CUR);
+    (void)ftello(f);
+#endif
+}
+
+int main()
+{
+    check(nullptr);
+}


### PR DESCRIPTION
The macro based solution has the downside of cluttering the global
namespace and requires duplication in both config headers.
Additionally ftello64 might not be available on some system where the
define check succeeds.

This solution uses a cpp file to wrap the functions adding enhanced
exists checks and additionally checking for overflow returning -1
(error) in that case as mandated by the standard for the filebuf
functions.

Finally a configure check determines general availability of LFS and if
it is not available the standard fseek/ftell functions are used.