### PR TITLE
Silence clang warning on armv7-a

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -153,7 +153,7 @@ for:
               OpenCppCoverage.exe --quiet --export_type cobertura:cobertura.xml `
               --sources ${env:APPVEYOR_BUILD_FOLDER} --modules "$PWD" `
               --cover_children --working_dir "$PWD" -- ctest -C Debug
-              bash codecov.sh -f cobertura.xml -n Appveyor -e APPVEYOR_BUILD_WORKER_IMAGE -X gcov -X search -Z
+              bash codecov.sh -f cobertura.xml -n Appveyor -e APPVEYOR_BUILD_WORKER_IMAGE -X gcov -X search -Z -U "-s" -A "-s"
             }
       # Build consumer example test
       - cmake --build . --config %configuration% --target install

--- a/include/boost/nowide/filebuf.hpp
+++ b/include/boost/nowide/filebuf.hpp
@@ -364,9 +364,16 @@ namespace nowide {
             setg(0, 0, 0);
             if(!off)
                 return true;
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif
             // coverity[result_independent_of_operands]
             if(off > std::numeric_limits<std::streamoff>::max())
                 return false;
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
             return detail::fseek(file_, static_cast<std::streamoff>(off), SEEK_CUR) == 0;
         }
 


### PR DESCRIPTION
```
In file included from ../libs/nowide/test/test_fstream.cpp:10:
In file included from ../boost/nowide/fstream.hpp:12:
../boost/nowide/filebuf.hpp:368:20: error: result of comparison of constant 9223372036854775807 with expression of type 'const int' is always false [-Werror,-Wtautological-constant-out-of-range-compare]
            if(off > std::numeric_limits<std::streamoff>::max())
               ~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```