### PR TITLE
Fix LFS detection (e.g. on Android)

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -16,7 +16,7 @@ local requirements =
 
 obj cxx11_moveable_fstreams : ../test/check_movable_fstreams.cpp ;
 explicit cxx11_moveable_fstreams ;
-obj lfs_support : ../test/check_lfs_support.cpp ;
+exe lfs_support : ../test/check_lfs_support.cpp ;
 explicit lfs_support ;
 
 project boost/nowide

--- a/test/check_lfs_support.cpp
+++ b/test/check_lfs_support.cpp
@@ -6,6 +6,10 @@
 //
 
 #define _LARGEFILE_SOURCE
+#ifndef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 64
+#endif
+
 #include <stdio.h>
 
 void check(FILE* f)


### PR DESCRIPTION
(At least) the Android NDKs stdio.h does define fseeko but not if __USE_FILE_OFFSET64
is defined and the API level is below 24.
As the usage of this macro was inconsistent between the check and the
use LFS could be wrongly detected leading to a compile failure later.

Fixes #111