### PR TITLE
Visual Studio 2013 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -94,6 +94,11 @@ environment:
 
     # CMake builds
     - CMAKE: true
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      GENERATOR: Visual Studio 12 2013 Win64
+      configuration: Debug
+      BOOST_ROOT: C:\Libraries\boost_1_58_0
+    - CMAKE: true
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       GENERATOR: Visual Studio 14 2015 Win64
       configuration: Debug

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,65 +32,65 @@ environment:
     # Include OpenCppCoverage and git bash (avoid WSL bash)
     PATH: 'C:\Program Files\OpenCppCoverage;C:\Program Files\Git\bin;%PATH%'
   matrix:
-    - FLAVOR: Visual Studio 2019
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      B2_CXXFLAGS: -permissive-
-      B2_CXXSTD: 14,17,latest # 2a
-      B2_TOOLSET: msvc-14.2
-
-    - FLAVOR: Visual Studio 2017 C++2a Strict
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      B2_CXXFLAGS: -permissive-
-      B2_CXXSTD: latest # 2a
-      B2_TOOLSET: msvc-14.1
-
-    - FLAVOR: Visual Studio 2017 C++14/17
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      B2_CXXSTD: 14,17
-      B2_TOOLSET: msvc-14.1
-
-    - FLAVOR: clang-cl
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      B2_ADDRESS_MODEL: 64
-      B2_CXXSTD: 11,14,17
-      B2_TOOLSET: clang-win
-
-    - FLAVOR: Visual Studio 2015, 2013
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      B2_TOOLSET: msvc-12.0,msvc-14.0
-
-    - FLAVOR: Visual Studio 2008, 2010, 2012
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      B2_TOOLSET: msvc-9.0,msvc-10.0,msvc-11.0
-      B2_ADDRESS_MODEL: 32 # No 64bit support
-
-    - FLAVOR: cygwin (32-bit)
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      ADDPATH: C:\cygwin\bin;
-      B2_ADDRESS_MODEL: 32
-      B2_CXXSTD: 03,11,14,1z
-      B2_TOOLSET: gcc
-
-    - FLAVOR: cygwin (64-bit)
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      ADDPATH: C:\cygwin64\bin;
-      B2_ADDRESS_MODEL: 64
-      B2_CXXSTD: 03,11,14,1z
-      B2_TOOLSET: gcc
-
-    - FLAVOR: mingw32
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      B2_ADDRESS_MODEL: 32
-      ADDPATH: C:\mingw\bin;
-      B2_TOOLSET: gcc
-      B2_CXXSTD: 03,11,14,1z
-
-    - FLAVOR: mingw64
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      ADDPATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;
-      B2_ADDRESS_MODEL: 64
-      B2_TOOLSET: gcc
-      B2_CXXSTD: 03,11,14,1z
+#    - FLAVOR: Visual Studio 2019
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+#      B2_CXXFLAGS: -permissive-
+#      B2_CXXSTD: 14,17,latest # 2a
+#      B2_TOOLSET: msvc-14.2
+#
+#    - FLAVOR: Visual Studio 2017 C++2a Strict
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+#      B2_CXXFLAGS: -permissive-
+#      B2_CXXSTD: latest # 2a
+#      B2_TOOLSET: msvc-14.1
+#
+#    - FLAVOR: Visual Studio 2017 C++14/17
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+#      B2_CXXSTD: 14,17
+#      B2_TOOLSET: msvc-14.1
+#
+#    - FLAVOR: clang-cl
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+#      B2_ADDRESS_MODEL: 64
+#      B2_CXXSTD: 11,14,17
+#      B2_TOOLSET: clang-win
+#
+#    - FLAVOR: Visual Studio 2015, 2013
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+#      B2_TOOLSET: msvc-12.0,msvc-14.0
+#
+#    - FLAVOR: Visual Studio 2008, 2010, 2012
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+#      B2_TOOLSET: msvc-9.0,msvc-10.0,msvc-11.0
+#      B2_ADDRESS_MODEL: 32 # No 64bit support
+#
+#    - FLAVOR: cygwin (32-bit)
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+#      ADDPATH: C:\cygwin\bin;
+#      B2_ADDRESS_MODEL: 32
+#      B2_CXXSTD: 03,11,14,1z
+#      B2_TOOLSET: gcc
+#
+#    - FLAVOR: cygwin (64-bit)
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+#      ADDPATH: C:\cygwin64\bin;
+#      B2_ADDRESS_MODEL: 64
+#      B2_CXXSTD: 03,11,14,1z
+#      B2_TOOLSET: gcc
+#
+#    - FLAVOR: mingw32
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+#      B2_ADDRESS_MODEL: 32
+#      ADDPATH: C:\mingw\bin;
+#      B2_TOOLSET: gcc
+#      B2_CXXSTD: 03,11,14,1z
+#
+#    - FLAVOR: mingw64
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+#      ADDPATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;
+#      B2_ADDRESS_MODEL: 64
+#      B2_TOOLSET: gcc
+#      B2_CXXSTD: 03,11,14,1z
 
     # CMake builds
     - CMAKE: true
@@ -98,34 +98,34 @@ environment:
       GENERATOR: Visual Studio 12 2013 Win64
       configuration: Debug
       BOOST_ROOT: C:\Libraries\boost_1_58_0
-    - CMAKE: true
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: Visual Studio 14 2015 Win64
-      configuration: Debug
-      BOOST_ROOT: C:\Libraries\boost_1_60_0
-    - CMAKE: true
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      GENERATOR: Visual Studio 16 2019
-      configuration: Debug
-      BOOST_ROOT: C:\Libraries\boost_1_71_0
-      COVERAGE: true
-      # Work around for https://community.codecov.io/t/bash-script-does-not-detect-appveyor/1094
-      APPVEYOR: true
-      CI: true
-    # Superproject CMake build
-    - FLAVOR: Superproject CMake build - VS 2019
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      BOOST_CMAKE: true
-    # Coverity
-    - COVERITY: true
-      # Coverity doesn't really support MSVC 2019 yet
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      GENERATOR: Visual Studio 15 2017
-      BOOST_ROOT: C:\Libraries\boost_1_69_0
-      COVERITY_SCAN_TOKEN:
-        secure: FzhGUr+AR/VOBGUta7dDLMDruolChnvyMSvsM/zLvPY=
-      COVERITY_SCAN_NOTIFICATION_EMAIL:
-        secure: Qq4PZ3QlpYtg3HEyn9r2Og==
+#    - CMAKE: true
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+#      GENERATOR: Visual Studio 14 2015 Win64
+#      configuration: Debug
+#      BOOST_ROOT: C:\Libraries\boost_1_60_0
+#    - CMAKE: true
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+#      GENERATOR: Visual Studio 16 2019
+#      configuration: Debug
+#      BOOST_ROOT: C:\Libraries\boost_1_71_0
+#      COVERAGE: true
+#      # Work around for https://community.codecov.io/t/bash-script-does-not-detect-appveyor/1094
+#      APPVEYOR: true
+#      CI: true
+#    # Superproject CMake build
+#    - FLAVOR: Superproject CMake build - VS 2019
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+#      BOOST_CMAKE: true
+#    # Coverity
+#    - COVERITY: true
+#      # Coverity doesn't really support MSVC 2019 yet
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+#      GENERATOR: Visual Studio 15 2017
+#      BOOST_ROOT: C:\Libraries\boost_1_69_0
+#      COVERITY_SCAN_TOKEN:
+#        secure: FzhGUr+AR/VOBGUta7dDLMDruolChnvyMSvsM/zLvPY=
+#      COVERITY_SCAN_NOTIFICATION_EMAIL:
+#        secure: Qq4PZ3QlpYtg3HEyn9r2Og==
 
 install:
   - git clone https://github.com/boostorg/boost-ci.git C:\boost-ci-cloned

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -55,13 +55,13 @@ environment:
       B2_CXXSTD: 11,14,17
       B2_TOOLSET: clang-win
 
-    - FLAVOR: Visual Studio 2015, 2013
+    - FLAVOR: Visual Studio 2015
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      B2_TOOLSET: msvc-12.0,msvc-14.0
+      B2_TOOLSET: msvc-14.0
 
-    - FLAVOR: Visual Studio 2008, 2010, 2012
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      B2_TOOLSET: msvc-9.0,msvc-10.0,msvc-11.0
+    - FLAVOR: Visual Studio 2008, 2010, 2012, 2013
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      B2_TOOLSET: msvc-9.0,msvc-10.0,msvc-11.0,msvc-12.0
       B2_ADDRESS_MODEL: 32 # No 64bit support
 
     - FLAVOR: cygwin (32-bit)

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,65 +32,65 @@ environment:
     # Include OpenCppCoverage and git bash (avoid WSL bash)
     PATH: 'C:\Program Files\OpenCppCoverage;C:\Program Files\Git\bin;%PATH%'
   matrix:
-#    - FLAVOR: Visual Studio 2019
-#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-#      B2_CXXFLAGS: -permissive-
-#      B2_CXXSTD: 14,17,latest # 2a
-#      B2_TOOLSET: msvc-14.2
-#
-#    - FLAVOR: Visual Studio 2017 C++2a Strict
-#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-#      B2_CXXFLAGS: -permissive-
-#      B2_CXXSTD: latest # 2a
-#      B2_TOOLSET: msvc-14.1
-#
-#    - FLAVOR: Visual Studio 2017 C++14/17
-#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-#      B2_CXXSTD: 14,17
-#      B2_TOOLSET: msvc-14.1
-#
-#    - FLAVOR: clang-cl
-#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-#      B2_ADDRESS_MODEL: 64
-#      B2_CXXSTD: 11,14,17
-#      B2_TOOLSET: clang-win
-#
-#    - FLAVOR: Visual Studio 2015, 2013
-#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-#      B2_TOOLSET: msvc-12.0,msvc-14.0
-#
-#    - FLAVOR: Visual Studio 2008, 2010, 2012
-#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-#      B2_TOOLSET: msvc-9.0,msvc-10.0,msvc-11.0
-#      B2_ADDRESS_MODEL: 32 # No 64bit support
-#
-#    - FLAVOR: cygwin (32-bit)
-#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-#      ADDPATH: C:\cygwin\bin;
-#      B2_ADDRESS_MODEL: 32
-#      B2_CXXSTD: 03,11,14,1z
-#      B2_TOOLSET: gcc
-#
-#    - FLAVOR: cygwin (64-bit)
-#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-#      ADDPATH: C:\cygwin64\bin;
-#      B2_ADDRESS_MODEL: 64
-#      B2_CXXSTD: 03,11,14,1z
-#      B2_TOOLSET: gcc
-#
-#    - FLAVOR: mingw32
-#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-#      B2_ADDRESS_MODEL: 32
-#      ADDPATH: C:\mingw\bin;
-#      B2_TOOLSET: gcc
-#      B2_CXXSTD: 03,11,14,1z
-#
-#    - FLAVOR: mingw64
-#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-#      ADDPATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;
-#      B2_ADDRESS_MODEL: 64
-#      B2_TOOLSET: gcc
-#      B2_CXXSTD: 03,11,14,1z
+    - FLAVOR: Visual Studio 2019
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      B2_CXXFLAGS: -permissive-
+      B2_CXXSTD: 14,17,latest # 2a
+      B2_TOOLSET: msvc-14.2
+
+    - FLAVOR: Visual Studio 2017 C++2a Strict
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      B2_CXXFLAGS: -permissive-
+      B2_CXXSTD: latest # 2a
+      B2_TOOLSET: msvc-14.1
+
+    - FLAVOR: Visual Studio 2017 C++14/17
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      B2_CXXSTD: 14,17
+      B2_TOOLSET: msvc-14.1
+
+    - FLAVOR: clang-cl
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      B2_ADDRESS_MODEL: 64
+      B2_CXXSTD: 11,14,17
+      B2_TOOLSET: clang-win
+
+    - FLAVOR: Visual Studio 2015, 2013
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      B2_TOOLSET: msvc-12.0,msvc-14.0
+
+    - FLAVOR: Visual Studio 2008, 2010, 2012
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      B2_TOOLSET: msvc-9.0,msvc-10.0,msvc-11.0
+      B2_ADDRESS_MODEL: 32 # No 64bit support
+
+    - FLAVOR: cygwin (32-bit)
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ADDPATH: C:\cygwin\bin;
+      B2_ADDRESS_MODEL: 32
+      B2_CXXSTD: 03,11,14,1z
+      B2_TOOLSET: gcc
+
+    - FLAVOR: cygwin (64-bit)
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ADDPATH: C:\cygwin64\bin;
+      B2_ADDRESS_MODEL: 64
+      B2_CXXSTD: 03,11,14,1z
+      B2_TOOLSET: gcc
+
+    - FLAVOR: mingw32
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      B2_ADDRESS_MODEL: 32
+      ADDPATH: C:\mingw\bin;
+      B2_TOOLSET: gcc
+      B2_CXXSTD: 03,11,14,1z
+
+    - FLAVOR: mingw64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      ADDPATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;
+      B2_ADDRESS_MODEL: 64
+      B2_TOOLSET: gcc
+      B2_CXXSTD: 03,11,14,1z
 
     # CMake builds
     - CMAKE: true
@@ -98,34 +98,34 @@ environment:
       GENERATOR: Visual Studio 12 2013 Win64
       configuration: Debug
       BOOST_ROOT: C:\Libraries\boost_1_58_0
-#    - CMAKE: true
-#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-#      GENERATOR: Visual Studio 14 2015 Win64
-#      configuration: Debug
-#      BOOST_ROOT: C:\Libraries\boost_1_60_0
-#    - CMAKE: true
-#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-#      GENERATOR: Visual Studio 16 2019
-#      configuration: Debug
-#      BOOST_ROOT: C:\Libraries\boost_1_71_0
-#      COVERAGE: true
-#      # Work around for https://community.codecov.io/t/bash-script-does-not-detect-appveyor/1094
-#      APPVEYOR: true
-#      CI: true
-#    # Superproject CMake build
-#    - FLAVOR: Superproject CMake build - VS 2019
-#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-#      BOOST_CMAKE: true
-#    # Coverity
-#    - COVERITY: true
-#      # Coverity doesn't really support MSVC 2019 yet
-#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-#      GENERATOR: Visual Studio 15 2017
-#      BOOST_ROOT: C:\Libraries\boost_1_69_0
-#      COVERITY_SCAN_TOKEN:
-#        secure: FzhGUr+AR/VOBGUta7dDLMDruolChnvyMSvsM/zLvPY=
-#      COVERITY_SCAN_NOTIFICATION_EMAIL:
-#        secure: Qq4PZ3QlpYtg3HEyn9r2Og==
+    - CMAKE: true
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      GENERATOR: Visual Studio 14 2015 Win64
+      configuration: Debug
+      BOOST_ROOT: C:\Libraries\boost_1_60_0
+    - CMAKE: true
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      GENERATOR: Visual Studio 16 2019
+      configuration: Debug
+      BOOST_ROOT: C:\Libraries\boost_1_71_0
+      COVERAGE: true
+      # Work around for https://community.codecov.io/t/bash-script-does-not-detect-appveyor/1094
+      APPVEYOR: true
+      CI: true
+    # Superproject CMake build
+    - FLAVOR: Superproject CMake build - VS 2019
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      BOOST_CMAKE: true
+    # Coverity
+    - COVERITY: true
+      # Coverity doesn't really support MSVC 2019 yet
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      GENERATOR: Visual Studio 15 2017
+      BOOST_ROOT: C:\Libraries\boost_1_69_0
+      COVERITY_SCAN_TOKEN:
+        secure: FzhGUr+AR/VOBGUta7dDLMDruolChnvyMSvsM/zLvPY=
+      COVERITY_SCAN_NOTIFICATION_EMAIL:
+        secure: Qq4PZ3QlpYtg3HEyn9r2Og==
 
 install:
   - git clone https://github.com/boostorg/boost-ci.git C:\boost-ci-cloned

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This is different to the version available prior to the inclusion in Boost.
 ### Requirements (All versions)
 
 * C++11 (or higher) compatible compiler
-    * MSVC 2015 and up work
+    * MSVC 2013 and up work
     * libstdc++ < 5 is unsupported as it is silently lacking C++11 features
 
 ### Requirements (Boost version)

--- a/include/boost/nowide/filebuf.hpp
+++ b/include/boost/nowide/filebuf.hpp
@@ -77,11 +77,12 @@ namespace nowide {
 #endif
         basic_filebuf(const basic_filebuf&) = delete;
         basic_filebuf& operator=(const basic_filebuf&) = delete;
-        basic_filebuf(basic_filebuf&& other) noexcept : basic_filebuf()
+        basic_filebuf(basic_filebuf&& other) BOOST_NOEXCEPT_OR_NOTHROW
+            : basic_filebuf()
         {
             swap(other);
         }
-        basic_filebuf& operator=(basic_filebuf&& other) noexcept
+        basic_filebuf& operator=(basic_filebuf&& other) BOOST_NOEXCEPT_OR_NOTHROW
         {
             swap(other);
             return *this;

--- a/include/boost/nowide/fstream.hpp
+++ b/include/boost/nowide/fstream.hpp
@@ -107,9 +107,12 @@ namespace nowide {
         using fstream_impl::swap;
         basic_ifstream(const basic_ifstream&) = delete;
         basic_ifstream& operator=(const basic_ifstream&) = delete;
-        basic_ifstream(basic_ifstream&& other) noexcept : fstream_impl(std::move(other))
+
+        basic_ifstream(basic_ifstream&& other) BOOST_NOEXCEPT_OR_NOTHROW
+            : fstream_impl(std::move(other))
         {}
-        basic_ifstream& operator=(basic_ifstream&& rhs) noexcept
+
+        basic_ifstream& operator=(basic_ifstream&& rhs) BOOST_NOEXCEPT_OR_NOTHROW
         {
             fstream_impl::operator=(std::move(rhs));
             return *this;
@@ -157,7 +160,9 @@ namespace nowide {
         using fstream_impl::swap;
         basic_ofstream(const basic_ofstream&) = delete;
         basic_ofstream& operator=(const basic_ofstream&) = delete;
-        basic_ofstream(basic_ofstream&& other) noexcept : fstream_impl(std::move(other))
+
+        basic_ofstream(basic_ofstream&& other) BOOST_NOEXCEPT_OR_NOTHROW
+            : fstream_impl(std::move(other))
         {}
         basic_ofstream& operator=(basic_ofstream&& rhs)
         {
@@ -213,7 +218,9 @@ namespace nowide {
         using fstream_impl::swap;
         basic_fstream(const basic_fstream&) = delete;
         basic_fstream& operator=(const basic_fstream&) = delete;
-        basic_fstream(basic_fstream&& other) noexcept : fstream_impl(std::move(other))
+
+        basic_fstream(basic_fstream&& other) BOOST_NOEXCEPT_OR_NOTHROW
+            : fstream_impl(std::move(other))
         {}
         basic_fstream& operator=(basic_fstream&& rhs)
         {
@@ -292,12 +299,12 @@ namespace nowide {
             fstream_impl& operator=(const fstream_impl&) = delete;
 
             // coverity[exn_spec_violation]
-            fstream_impl(fstream_impl&& other) noexcept :
-                base_buf_holder(std::move(other)), stream_base(std::move(other))
+            fstream_impl(fstream_impl&& other) BOOST_NOEXCEPT_OR_NOTHROW
+                : base_buf_holder(std::move(other)), stream_base(std::move(other))
             {
                 this->set_rdbuf(rdbuf());
             }
-            fstream_impl& operator=(fstream_impl&& rhs) noexcept
+            fstream_impl& operator=(fstream_impl&& rhs) BOOST_NOEXCEPT_OR_NOTHROW
             {
                 base_buf_holder::operator=(std::move(rhs));
                 stream_base::operator=(std::move(rhs));

--- a/include/boost/nowide/fstream.hpp
+++ b/include/boost/nowide/fstream.hpp
@@ -277,7 +277,31 @@ namespace nowide {
         struct buf_holder
         {
             T buf_;
+
+            buf_holder() = default;
+
+            buf_holder(const buf_holder&) = delete;
+
+            // VS 2013 doesn't generate move ctor/move assignment operator
+            // automatically.
+            buf_holder(buf_holder&& other) BOOST_NOEXCEPT_OR_NOTHROW
+            {
+                swap(other);
+            }
+
+            buf_holder& operator=(buf_holder other) BOOST_NOEXCEPT_OR_NOTHROW
+            {
+                swap(other);
+                return *this;
+            }
+
+            void swap(buf_holder& other) BOOST_NOEXCEPT_OR_NOTHROW
+            {
+                using std::swap;
+                swap(buf_, other.buf_);
+            }
         };
+
         template<typename CharType, typename Traits, typename T_StreamType, int>
         class fstream_impl : private buf_holder<basic_filebuf<CharType, Traits>>, // must be first due to init order
                              public T_StreamType::template stream_base<CharType, Traits>::type

--- a/include/boost/nowide/utf8_codecvt.hpp
+++ b/include/boost/nowide/utf8_codecvt.hpp
@@ -73,15 +73,15 @@ namespace nowide {
             next = from;
             return std::codecvt_base::ok;
         }
-        int do_encoding() const noexcept override
+        int do_encoding() const BOOST_NOEXCEPT_OR_NOTHROW override
         {
             return 0;
         }
-        int do_max_length() const noexcept override
+        int do_max_length() const BOOST_NOEXCEPT_OR_NOTHROW override
         {
             return 4;
         }
-        bool do_always_noconv() const noexcept override
+        bool do_always_noconv() const BOOST_NOEXCEPT_OR_NOTHROW override
         {
             return false;
         }
@@ -304,15 +304,15 @@ namespace nowide {
             next = from;
             return std::codecvt_base::ok;
         }
-        int do_encoding() const noexcept override
+        int do_encoding() const BOOST_NOEXCEPT_OR_NOTHROW override
         {
             return 0;
         }
-        int do_max_length() const noexcept override
+        int do_max_length() const BOOST_NOEXCEPT_OR_NOTHROW override
         {
             return 4;
         }
-        bool do_always_noconv() const noexcept override
+        bool do_always_noconv() const BOOST_NOEXCEPT_OR_NOTHROW override
         {
             return false;
         }

--- a/src/filebuf.cpp
+++ b/src/filebuf.cpp
@@ -43,7 +43,7 @@ namespace nowide {
     namespace detail {
 
         template<typename T, typename U>
-        constexpr bool is_in_range(U value)
+        BOOST_CONSTEXPR bool is_in_range(U value)
         {
             static_assert(std::is_signed<T>::value == std::is_signed<U>::value,
                           "Mixed sign comparison can lead to problems below");

--- a/standalone/config.hpp
+++ b/standalone/config.hpp
@@ -71,6 +71,14 @@
 #define BOOST_NOWIDE_FALLTHROUGH
 #endif
 
+#if defined(_MSC_VER) && _MSC_VER < 1900 // Visual Studio 2015
+#define BOOST_CONSTEXPR
+#define BOOST_NOEXCEPT_OR_NOTHROW throw()
+#else
+#define BOOST_CONSTEXPR constexpr
+#define BOOST_NOEXCEPT_OR_NOTHROW noexcept
+#endif
+
 #if defined __GNUC__
 #define BOOST_LIKELY(x) __builtin_expect(x, 1)
 #define BOOST_UNLIKELY(x) __builtin_expect(x, 0)

--- a/test/test_stackstring.cpp
+++ b/test/test_stackstring.cpp
@@ -24,7 +24,12 @@ class test_basic_stackstring : public boost::nowide::basic_stackstring<CharOut, 
 public:
     using parent = boost::nowide::basic_stackstring<CharOut, CharIn, BufferSize>;
 
-    using parent::parent;
+    test_basic_stackstring() : parent()
+    {}
+
+    explicit test_basic_stackstring(const input_char* input) : parent(input)
+    {}
+
     using parent::uses_stack_memory;
     bool uses_heap_memory() const
     {

--- a/test/test_stackstring.cpp
+++ b/test/test_stackstring.cpp
@@ -27,7 +27,7 @@ public:
     test_basic_stackstring() : parent()
     {}
 
-    explicit test_basic_stackstring(const input_char* input) : parent(input)
+    explicit test_basic_stackstring(const CharIn* input) : parent(input)
     {}
 
     using parent::uses_stack_memory;

--- a/test/test_stat.cpp
+++ b/test/test_stat.cpp
@@ -38,7 +38,7 @@ void test_main(int, char** argv, char**)
     FILE* f = boost::nowide::fopen(filename.c_str(), "wb");
     TEST(f);
     const char testData[] = "Hello World";
-    constexpr size_t testDataSize = sizeof(testData);
+    const size_t testDataSize = sizeof(testData);
     TEST(std::fwrite(testData, sizeof(char), testDataSize, f) == testDataSize);
     std::fclose(f);
     {


### PR DESCRIPTION
Would you consider adding support for VS 2013, implemented in this PR? I know it's old, but I still use it on AppVeyor for some things. All the tests seem to pass, including the VS 2013 ones on AppVeyor:

* https://github.com/egor-tensin/nowide/actions/runs/284973434
* https://travis-ci.com/github/egor-tensin/nowide/builds/187913934
* https://ci.appveyor.com/project/egor-tensin/nowide/builds/35542850

It's just a few macros to abstract away things like `noexcept` and `constexpr` + some minor code changes.