### PR TITLE
Add support for string_view

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 
 cmake_minimum_required(VERSION 3.9)
 # Version number starts at 10 to avoid conflicts with Boost version
-set(_version 11.0.0)
+set(_version 11.1.0)
 if(BOOST_SUPERPROJECT_SOURCE_DIR)
   set(_version ${BOOST_SUPERPROJECT_VERSION})
 endif()

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -582,7 +582,7 @@ FILE_PATTERNS          = *.cpp *.hpp *.md *.dox
 # should be searched for input files as well. Possible values are YES and NO.
 # If left blank NO is used.
 
-RECURSIVE              = NO
+RECURSIVE              = YES
 
 # The EXCLUDE tag can be used to specify files and/or directories that should
 # excluded from the INPUT source files. This way you can easily exclude a

--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -12,7 +12,8 @@
 
 \subsection changelog_11_1_0 Nowide 11.1.0
 
-- Add support for string_view to `convert_string`, `narrow` and `widen`
+- Add support for string_view to `narrow` and `widen`
+- Add support for UTF character types such as `char16_t`
 
 \subsection changelog_11_0_0 Nowide 11.0.0 (Boost 1.74)
 
@@ -23,7 +24,7 @@
 
 \subsection changelog_10_0_2 Nowide 10.0.2
 
-- boost::nowide::cin now ignores CR (\r) characters and treats CTRL+Z at the beginning of a line as EOF (matching std::cin behavior)
+- boost::nowide::cin now ignores CR (\\r) characters and treats CTRL+Z at the beginning of a line as EOF (matching std::cin behavior)
 - boost::nowide::cin supports sync by flushing the input and console buffer
 
 \subsection changelog_10_0_1 Nowide 10.0.1 (Boost 1.73)

--- a/doc/changelog.dox
+++ b/doc/changelog.dox
@@ -10,6 +10,10 @@
 
 \section changelog Changelog
 
+\subsection changelog_11_1_0 Nowide 11.1.0
+
+- Add support for string_view to `convert_string`, `narrow` and `widen`
+
 \subsection changelog_11_0_0 Nowide 11.0.0 (Boost 1.74)
 
 - Require C++11 compatible compiler and stdlib

--- a/include/boost/nowide/convert.hpp
+++ b/include/boost/nowide/convert.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_NOWIDE_CONVERT_HPP_INCLUDED
 #define BOOST_NOWIDE_CONVERT_HPP_INCLUDED
 
+#include <boost/nowide/detail/is_string_container.hpp>
 #include <boost/nowide/utf/convert.hpp>
 #include <string>
 
@@ -87,9 +88,12 @@ namespace nowide {
     /// \param s Input string
     /// Any illegal sequences are replaced with the replacement character, see #BOOST_NOWIDE_REPLACEMENT_CHARACTER
     ///
-    inline std::string narrow(const std::wstring& s)
+    template<typename StringOrStringView,
+             typename = detail::requires_string_container<StringOrStringView>,
+             typename = detail::requires_wide_data<StringOrStringView>>
+    inline std::string narrow(const StringOrStringView& s)
     {
-        return narrow(s.c_str(), s.size());
+        return utf::convert_string<char>(s);
     }
 
     ///
@@ -119,9 +123,12 @@ namespace nowide {
     /// \param s Input string
     /// Any illegal sequences are replaced with the replacement character, see #BOOST_NOWIDE_REPLACEMENT_CHARACTER
     ///
-    inline std::wstring widen(const std::string& s)
+    template<typename StringOrStringView,
+             typename = detail::requires_string_container<StringOrStringView>,
+             typename = detail::requires_narrow_data<StringOrStringView>>
+    inline std::wstring widen(const StringOrStringView& s)
     {
-        return widen(s.c_str(), s.size());
+        return utf::convert_string<wchar_t>(s);
     }
 } // namespace nowide
 } // namespace boost

--- a/include/boost/nowide/convert.hpp
+++ b/include/boost/nowide/convert.hpp
@@ -1,5 +1,6 @@
 //
 //  Copyright (c) 2012 Artyom Beilis (Tonkikh)
+//  Copyright (c) 2020 Alexander Grund
 //
 //  Distributed under the Boost Software License, Version 1.0. (See
 //  accompanying file LICENSE or copy at

--- a/include/boost/nowide/convert.hpp
+++ b/include/boost/nowide/convert.hpp
@@ -69,7 +69,8 @@ namespace nowide {
     /// \param count Number of characters to convert
     /// Any illegal sequences are replaced with the replacement character, see #BOOST_NOWIDE_REPLACEMENT_CHARACTER
     ///
-    inline std::string narrow(const wchar_t* s, size_t count)
+    template<typename T_Char, typename = detail::requires_wide_char<T_Char>>
+    inline std::string narrow(const T_Char* s, size_t count)
     {
         return utf::convert_string<char>(s, s + count);
     }
@@ -79,7 +80,8 @@ namespace nowide {
     /// \param s NULL terminated input string
     /// Any illegal sequences are replaced with the replacement character, see #BOOST_NOWIDE_REPLACEMENT_CHARACTER
     ///
-    inline std::string narrow(const wchar_t* s)
+    template<typename T_Char, typename = detail::requires_wide_char<T_Char>>
+    inline std::string narrow(const T_Char* s)
     {
         return narrow(s, utf::strlen(s));
     }
@@ -94,7 +96,7 @@ namespace nowide {
              typename = detail::requires_wide_data<StringOrStringView>>
     inline std::string narrow(const StringOrStringView& s)
     {
-        return utf::convert_string<char>(s);
+        return utf::convert_string<char>(s.data(), s.data() + s.size());
     }
 
     ///
@@ -104,7 +106,8 @@ namespace nowide {
     /// \param count Number of characters to convert
     /// Any illegal sequences are replaced with the replacement character, see #BOOST_NOWIDE_REPLACEMENT_CHARACTER
     ///
-    inline std::wstring widen(const char* s, size_t count)
+    template<typename T_Char, typename = detail::requires_narrow_char<T_Char>>
+    inline std::wstring widen(const T_Char* s, size_t count)
     {
         return utf::convert_string<wchar_t>(s, s + count);
     }
@@ -114,7 +117,8 @@ namespace nowide {
     /// \param s NULL terminated input string
     /// Any illegal sequences are replaced with the replacement character, see #BOOST_NOWIDE_REPLACEMENT_CHARACTER
     ///
-    inline std::wstring widen(const char* s)
+    template<typename T_Char, typename = detail::requires_narrow_char<T_Char>>
+    inline std::wstring widen(const T_Char* s)
     {
         return widen(s, utf::strlen(s));
     }
@@ -129,7 +133,7 @@ namespace nowide {
              typename = detail::requires_narrow_data<StringOrStringView>>
     inline std::wstring widen(const StringOrStringView& s)
     {
-        return utf::convert_string<wchar_t>(s);
+        return utf::convert_string<wchar_t>(s.data(), s.data() + s.size());
     }
 } // namespace nowide
 } // namespace boost

--- a/include/boost/nowide/convert.hpp
+++ b/include/boost/nowide/convert.hpp
@@ -91,9 +91,7 @@ namespace nowide {
     /// \param s Input string
     /// Any illegal sequences are replaced with the replacement character, see #BOOST_NOWIDE_REPLACEMENT_CHARACTER
     ///
-    template<typename StringOrStringView,
-             typename = detail::requires_string_container<StringOrStringView>,
-             typename = detail::requires_wide_data<StringOrStringView>>
+    template<typename StringOrStringView, typename = detail::requires_wide_string_container<StringOrStringView>>
     inline std::string narrow(const StringOrStringView& s)
     {
         return utf::convert_string<char>(s.data(), s.data() + s.size());
@@ -128,9 +126,7 @@ namespace nowide {
     /// \param s Input string
     /// Any illegal sequences are replaced with the replacement character, see #BOOST_NOWIDE_REPLACEMENT_CHARACTER
     ///
-    template<typename StringOrStringView,
-             typename = detail::requires_string_container<StringOrStringView>,
-             typename = detail::requires_narrow_data<StringOrStringView>>
+    template<typename StringOrStringView, typename = detail::requires_narrow_string_container<StringOrStringView>>
     inline std::wstring widen(const StringOrStringView& s)
     {
         return utf::convert_string<wchar_t>(s.data(), s.data() + s.size());

--- a/include/boost/nowide/detail/is_string_container.hpp
+++ b/include/boost/nowide/detail/is_string_container.hpp
@@ -53,36 +53,37 @@ namespace nowide {
 
         template<typename T>
         using const_data_result = decltype(std::declval<const T>().data());
+        /// Return the size of the char type returned by the data() member function
+        template<typename T>
+        using get_data_width =
+          std::integral_constant<std::size_t, sizeof(typename std::remove_pointer<const_data_result<T>>::type)>;
         template<typename T>
         using size_result = decltype(std::declval<T>().size());
+        /// Return true if the data() member function returns a pointer to a type of size 1
+        template<typename T>
+        using has_narrow_data = std::integral_constant<bool, (get_data_width<T>::value == 1)>;
 
         /// Return true if T is a string container, e.g. std::basic_string, std::basic_string_view
         /// Requires a static value `npos`, a member function `size()` returning an integral,
         /// and a member function `data()` returning a C string
-        template<typename T, typename = void>
+        template<typename T, bool isNarrow, typename = void>
         struct is_string_container : std::false_type
         {};
-        template<typename T>
-        struct is_string_container<T, void_t<decltype(T::npos), size_result<T>, const_data_result<T>>>
+        // clang-format off
+        template<typename T, bool isNarrow>
+        struct is_string_container<T, isNarrow, void_t<decltype(T::npos), size_result<T>, const_data_result<T>>>
             : std::integral_constant<bool,
                                      std::is_integral<decltype(T::npos)>::value
                                        && std::is_integral<size_result<T>>::value
-                                       && is_c_string<const_data_result<T>>::value>
+                                       && is_c_string<const_data_result<T>>::value
+                                       && isNarrow == has_narrow_data<T>::value>
         {};
+        // clang-format on
         template<typename T>
-        using requires_string_container = typename std::enable_if<is_string_container<T>::value>::type;
+        using requires_narrow_string_container = typename std::enable_if<is_string_container<T, true>::value>::type;
+        template<typename T>
+        using requires_wide_string_container = typename std::enable_if<is_string_container<T, false>::value>::type;
 
-        template<typename T, typename = void>
-        struct get_data_width : std::integral_constant<std::size_t, 0>
-        {};
-        template<typename T>
-        struct get_data_width<T, void_t<const_data_result<T>>>
-            : std::integral_constant<std::size_t, sizeof(typename std::remove_pointer<const_data_result<T>>::type)>
-        {};
-        template<typename T>
-        using requires_narrow_data = typename std::enable_if<get_data_width<T>::value == 1>::type;
-        template<typename T>
-        using requires_wide_data = typename std::enable_if<(get_data_width<T>::value > 1)>::type;
         template<typename T>
         using requires_narrow_char = typename std::enable_if<sizeof(T) == 1 && is_char_type<T>::value>::type;
         template<typename T>

--- a/include/boost/nowide/detail/is_string_container.hpp
+++ b/include/boost/nowide/detail/is_string_container.hpp
@@ -43,8 +43,6 @@ namespace nowide {
         struct is_char_type<char8_t> : std::true_type
         {};
 #endif
-        template<typename T>
-        using requires_char_type = typename std::enable_if<is_char_type<T>::value>::type;
 
         template<typename T>
         struct is_c_string : std::false_type
@@ -59,7 +57,7 @@ namespace nowide {
         using size_result = decltype(std::declval<T>().size());
 
         /// Return true if T is a string container, e.g. std::basic_string, std::basic_string_view
-        /// Requires a static value `npos` a member function `size()` returning an integral,
+        /// Requires a static value `npos`, a member function `size()` returning an integral,
         /// and a member function `data()` returning a C string
         template<typename T, typename = void>
         struct is_string_container : std::false_type
@@ -85,6 +83,10 @@ namespace nowide {
         using requires_narrow_data = typename std::enable_if<get_data_width<T>::value == 1>::type;
         template<typename T>
         using requires_wide_data = typename std::enable_if<(get_data_width<T>::value > 1)>::type;
+        template<typename T>
+        using requires_narrow_char = typename std::enable_if<sizeof(T) == 1 && is_char_type<T>::value>::type;
+        template<typename T>
+        using requires_wide_char = typename std::enable_if<(sizeof(T) > 1) && is_char_type<T>::value>::type;
 
     } // namespace detail
 } // namespace nowide

--- a/include/boost/nowide/detail/is_string_container.hpp
+++ b/include/boost/nowide/detail/is_string_container.hpp
@@ -1,0 +1,93 @@
+//
+//  Copyright (c) 2020 Alexander Grund
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+#ifndef BOOST_NOWIDE_DETAIL_IS_STRING_CONTAINER_HPP_INCLUDED
+#define BOOST_NOWIDE_DETAIL_IS_STRING_CONTAINER_HPP_INCLUDED
+
+#include <cstddef>
+#include <type_traits>
+
+namespace boost {
+namespace nowide {
+    namespace detail {
+        template<class...>
+        struct make_void
+        {
+            typedef void type;
+        };
+
+        template<class... Ts>
+        using void_t = typename make_void<Ts...>::type;
+
+        template<typename T>
+        struct is_char_type : std::false_type
+        {};
+        template<>
+        struct is_char_type<char> : std::true_type
+        {};
+        template<>
+        struct is_char_type<wchar_t> : std::true_type
+        {};
+        template<>
+        struct is_char_type<char16_t> : std::true_type
+        {};
+        template<>
+        struct is_char_type<char32_t> : std::true_type
+        {};
+#ifdef __cpp_char8_t
+        template<>
+        struct is_char_type<char8_t> : std::true_type
+        {};
+#endif
+        template<typename T>
+        using requires_char_type = typename std::enable_if<is_char_type<T>::value>::type;
+
+        template<typename T>
+        struct is_c_string : std::false_type
+        {};
+        template<typename T>
+        struct is_c_string<const T*> : is_char_type<T>
+        {};
+
+        template<typename T>
+        using const_data_result = decltype(std::declval<const T>().data());
+        template<typename T>
+        using size_result = decltype(std::declval<T>().size());
+
+        /// Return true if T is a string container, e.g. std::basic_string, std::basic_string_view
+        /// Requires a static value `npos` a member function `size()` returning an integral,
+        /// and a member function `data()` returning a C string
+        template<typename T, typename = void>
+        struct is_string_container : std::false_type
+        {};
+        template<typename T>
+        struct is_string_container<T, void_t<decltype(T::npos), size_result<T>, const_data_result<T>>>
+            : std::integral_constant<bool,
+                                     std::is_integral<decltype(T::npos)>::value
+                                       && std::is_integral<size_result<T>>::value
+                                       && is_c_string<const_data_result<T>>::value>
+        {};
+        template<typename T>
+        using requires_string_container = typename std::enable_if<is_string_container<T>::value>::type;
+
+        template<typename T, typename = void>
+        struct get_data_width : std::integral_constant<std::size_t, 0>
+        {};
+        template<typename T>
+        struct get_data_width<T, void_t<const_data_result<T>>>
+            : std::integral_constant<std::size_t, sizeof(typename std::remove_pointer<const_data_result<T>>::type)>
+        {};
+        template<typename T>
+        using requires_narrow_data = typename std::enable_if<get_data_width<T>::value == 1>::type;
+        template<typename T>
+        using requires_wide_data = typename std::enable_if<(get_data_width<T>::value > 1)>::type;
+
+    } // namespace detail
+} // namespace nowide
+} // namespace boost
+
+#endif

--- a/include/boost/nowide/utf/convert.hpp
+++ b/include/boost/nowide/utf/convert.hpp
@@ -1,5 +1,6 @@
 //
 //  Copyright (c) 2012 Artyom Beilis (Tonkikh)
+//  Copyright (c) 2020 Alexander Grund
 //
 //  Distributed under the Boost Software License, Version 1.0. (See
 //  accompanying file LICENSE or copy at
@@ -17,6 +18,19 @@
 namespace boost {
 namespace nowide {
     namespace utf {
+
+        /// Return the length of the given string in code units.
+        /// That is the number of elements of type Char until the first NULL character
+        /// Equivalent to `std::strlen(s)` but can handle wide-strings
+        template<typename Char>
+        size_t strlen(const Char* s)
+        {
+            const Char* end = s;
+            while(*end)
+                end++;
+            return end - s;
+        }
+
         /// Convert a buffer of UTF sequences in the range [source_begin, source_end)
         /// from \tparam CharIn to \tparam CharOut to the output \a buffer of size \a buffer_size.
         ///
@@ -88,16 +102,14 @@ namespace nowide {
             return convert_string<CharOut>(input.data(), input.data() + input.size());
         }
 
-        /// Return the length of the given string in code units.
-        /// That is the number of elements of type Char until the first NULL character
-        /// Equivalent to `std::strlen(s)` but can handle wide-strings
-        template<typename Char>
-        size_t strlen(const Char* s)
+        /// Convert the UTF sequences in the NULL terminated input string to \tparam CharOut
+        /// and return it as a string
+        ///
+        /// Any illegal sequences are replaced with the replacement character, see #BOOST_NOWIDE_REPLACEMENT_CHARACTER
+        template<typename CharOut, typename CharIn, typename = detail::requires_char_type<CharIn>>
+        std::basic_string<CharOut> convert_string(const CharIn* input)
         {
-            const Char* end = s;
-            while(*end)
-                end++;
-            return end - s;
+            return convert_string<CharOut>(input, input + strlen(input));
         }
 
     } // namespace utf

--- a/include/boost/nowide/utf/convert.hpp
+++ b/include/boost/nowide/utf/convert.hpp
@@ -20,7 +20,7 @@ namespace nowide {
     namespace utf {
 
         /// Return the length of the given string in code units.
-        /// That is the number of elements of type Char until the first NULL character
+        /// That is the number of elements of type Char until the first NULL character.
         /// Equivalent to `std::strlen(s)` but can handle wide-strings
         template<typename Char>
         size_t strlen(const Char* s)
@@ -32,7 +32,7 @@ namespace nowide {
         }
 
         /// Convert a buffer of UTF sequences in the range [source_begin, source_end)
-        /// from \tparam CharIn to \tparam CharOut to the output \a buffer of size \a buffer_size.
+        /// from \a CharIn to \a CharOut to the output \a buffer of size \a buffer_size.
         ///
         /// \return original buffer containing the NULL terminated string or NULL
         ///
@@ -66,10 +66,11 @@ namespace nowide {
             return rv;
         }
 
-        /// Convert the UTF sequences in range [begin, end) from \tparam CharIn to \tparam CharOut
+        /// Convert the UTF sequences in range [begin, end) from \a CharIn to \a CharOut
         /// and return it as a string
         ///
         /// Any illegal sequences are replaced with the replacement character, see #BOOST_NOWIDE_REPLACEMENT_CHARACTER
+        /// \tparam CharOut Output character type
         template<typename CharOut, typename CharIn>
         std::basic_string<CharOut> convert_string(const CharIn* begin, const CharIn* end)
         {
@@ -88,28 +89,6 @@ namespace nowide {
                 utf_traits<CharOut>::encode(c, inserter);
             }
             return result;
-        }
-
-        /// Convert the UTF sequences in input (a string or string_view like instance) to \tparam CharOut
-        /// and return it as a string
-        ///
-        /// Any illegal sequences are replaced with the replacement character, see #BOOST_NOWIDE_REPLACEMENT_CHARACTER
-        template<typename CharOut,
-                 typename StringOrStringView,
-                 typename = detail::requires_string_container<StringOrStringView>>
-        std::basic_string<CharOut> convert_string(const StringOrStringView& input)
-        {
-            return convert_string<CharOut>(input.data(), input.data() + input.size());
-        }
-
-        /// Convert the UTF sequences in the NULL terminated input string to \tparam CharOut
-        /// and return it as a string
-        ///
-        /// Any illegal sequences are replaced with the replacement character, see #BOOST_NOWIDE_REPLACEMENT_CHARACTER
-        template<typename CharOut, typename CharIn, typename = detail::requires_char_type<CharIn>>
-        std::basic_string<CharOut> convert_string(const CharIn* input)
-        {
-            return convert_string<CharOut>(input, input + strlen(input));
         }
 
     } // namespace utf

--- a/include/boost/nowide/utf/convert.hpp
+++ b/include/boost/nowide/utf/convert.hpp
@@ -44,7 +44,7 @@ namespace nowide {
         {
             CharOut* rv = buffer;
             if(buffer_size == 0)
-                return 0;
+                return nullptr;
             buffer_size--;
             while(source_begin != source_end)
             {

--- a/include/boost/nowide/utf/convert.hpp
+++ b/include/boost/nowide/utf/convert.hpp
@@ -8,6 +8,7 @@
 #ifndef BOOST_NOWIDE_UTF_CONVERT_HPP_INCLUDED
 #define BOOST_NOWIDE_UTF_CONVERT_HPP_INCLUDED
 
+#include <boost/nowide/detail/is_string_container.hpp>
 #include <boost/nowide/replacement.hpp>
 #include <boost/nowide/utf/utf.hpp>
 #include <iterator>
@@ -77,6 +78,13 @@ namespace nowide {
                 utf_traits<CharOut>::encode(c, inserter);
             }
             return result;
+        }
+        template<typename CharOut,
+                 typename StringOrStringView,
+                 typename = detail::requires_string_container<StringOrStringView>>
+        std::basic_string<CharOut> convert_string(const StringOrStringView& input)
+        {
+            return convert_string<CharOut>(input.data(), input.data() + input.size());
         }
 
         /// Return the length of the given string in code units.

--- a/include/boost/nowide/utf/convert.hpp
+++ b/include/boost/nowide/utf/convert.hpp
@@ -17,7 +17,6 @@
 namespace boost {
 namespace nowide {
     namespace utf {
-        ///
         /// Convert a buffer of UTF sequences in the range [source_begin, source_end)
         /// from \tparam CharIn to \tparam CharOut to the output \a buffer of size \a buffer_size.
         ///
@@ -25,7 +24,6 @@ namespace nowide {
         ///
         /// If there is not enough room in the buffer NULL is returned, and the content of the buffer is undefined.
         /// Any illegal sequences are replaced with the replacement character, see #BOOST_NOWIDE_REPLACEMENT_CHARACTER
-        ///
         template<typename CharOut, typename CharIn>
         CharOut*
         convert_buffer(CharOut* buffer, size_t buffer_size, const CharIn* source_begin, const CharIn* source_end)
@@ -54,12 +52,10 @@ namespace nowide {
             return rv;
         }
 
-        ///
         /// Convert the UTF sequences in range [begin, end) from \tparam CharIn to \tparam CharOut
         /// and return it as a string
         ///
         /// Any illegal sequences are replaced with the replacement character, see #BOOST_NOWIDE_REPLACEMENT_CHARACTER
-        ///
         template<typename CharOut, typename CharIn>
         std::basic_string<CharOut> convert_string(const CharIn* begin, const CharIn* end)
         {
@@ -79,6 +75,11 @@ namespace nowide {
             }
             return result;
         }
+
+        /// Convert the UTF sequences in input (a string or string_view like instance) to \tparam CharOut
+        /// and return it as a string
+        ///
+        /// Any illegal sequences are replaced with the replacement character, see #BOOST_NOWIDE_REPLACEMENT_CHARACTER
         template<typename CharOut,
                  typename StringOrStringView,
                  typename = detail::requires_string_container<StringOrStringView>>

--- a/include/boost/nowide/utf/utf.hpp
+++ b/include/boost/nowide/utf/utf.hpp
@@ -235,14 +235,14 @@ namespace nowide {
                     c = (c << 6) | (tmp & 0x3F);
                 }
 
-                // Check code point validity: no surrogates and
-                // valid range
-                if(BOOST_UNLIKELY(!is_valid_codepoint(c)))
+                // Check code point validity:
+                // - no surrogates and valid range
+                // - most compact representation
+                if(BOOST_UNLIKELY(!is_valid_codepoint(c)) || BOOST_UNLIKELY(width(c) != trail_size + 1))
+                {
+                    p -= trail_size;
                     return illegal;
-
-                // make sure it is the most compact representation
-                if(BOOST_UNLIKELY(width(c) != trail_size + 1))
-                    return illegal;
+                }
 
                 return c;
             }

--- a/include/boost/nowide/utf/utf.hpp
+++ b/include/boost/nowide/utf/utf.hpp
@@ -17,7 +17,7 @@ namespace nowide {
     ///
     /// \brief Namespace that holds basic operations on UTF encoded sequences
     ///
-    /// All functions defined in this namespace do not require linking with Boost.Nowide library
+    /// All functions defined in this namespace do not require linking with Boost.Nowide library.
     /// Extracted from Boost.Locale
     ///
     namespace utf {

--- a/test/test_convert.cpp
+++ b/test/test_convert.cpp
@@ -8,9 +8,15 @@
 
 #include <boost/nowide/convert.hpp>
 #include <iostream>
+#include <string>
 
 #include "test.hpp"
 #include "test_sets.hpp"
+
+#ifdef __cpp_lib_string_view
+#include <string_view>
+#define BOOST_NOWIDE_TEST_STD_STRINGVIEW
+#endif
 
 #if defined(BOOST_MSVC) && BOOST_MSVC < 1700
 #pragma warning(disable : 4428) // universal-character-name encountered in source
@@ -68,6 +74,18 @@ std::string narrow_raw_string_and_size(const std::wstring& s)
     return boost::nowide::narrow(s2.c_str(), s.size());
 }
 
+#ifdef BOOST_NOWIDE_TEST_STD_STRINGVIEW
+std::wstring widen_string_view(const std::string& s)
+{
+    return boost::nowide::widen(std::string_view(s));
+}
+
+std::string narrow_string_view(const std::wstring& s)
+{
+    return boost::nowide::narrow(std::wstring_view(s));
+}
+#endif
+
 void test_main(int, char**, char**)
 {
     std::string hello = "\xd7\xa9\xd7\x9c\xd7\x95\xd7\x9d";
@@ -115,4 +133,8 @@ void test_main(int, char**, char**)
     run_all(widen_raw_string_and_size, narrow_raw_string_and_size);
     std::cout << "- (const std::string&)" << std::endl;
     run_all(boost::nowide::widen, boost::nowide::narrow);
+#ifdef BOOST_NOWIDE_TEST_STD_STRINGVIEW
+    std::cout << "- (std::string_view)" << std::endl;
+    run_all(widen_string_view, narrow_string_view);
+#endif
 }

--- a/test/test_convert.cpp
+++ b/test/test_convert.cpp
@@ -108,6 +108,10 @@ void test_main(int, char**, char**)
         TEST(buf == whello_3);
         TEST(boost::nowide::widen(buf, 5, b, b) == buf && buf[0] == 0);
         TEST(boost::nowide::widen(buf, 5, b, b + 2) == buf && buf[1] == 0 && buf[0] == whello[0]);
+
+        // Raw literals are also possible
+        TEST(boost::nowide::widen("\xd7\xa9\xd7\x9c\xd7\x95\xd7\x9d") == whello);
+        TEST(boost::nowide::utf::convert_string<wchar_t>("\xd7\xa9\xd7\x9c\xd7\x95\xd7\x9d") == whello);
     }
     std::cout << "- boost::nowide::narrow" << std::endl;
     {
@@ -121,6 +125,10 @@ void test_main(int, char**, char**)
         TEST(boost::nowide::narrow(buf, 8, b, e) == 0);
         TEST(boost::nowide::narrow(buf, 7, b, e - 1) == buf);
         TEST(buf == hello.substr(0, 6));
+
+        // Raw literals are also possible
+        TEST(boost::nowide::narrow(L"\u05e9\u05dc\u05d5\u05dd") == hello);
+        TEST(boost::nowide::utf::convert_string<char>(L"\u05e9\u05dc\u05d5\u05dd") == hello);
     }
 
     std::cout << "- (output_buffer, buffer_size, input_raw_string)" << std::endl;

--- a/test/test_sets.hpp
+++ b/test/test_sets.hpp
@@ -33,6 +33,17 @@ const std::wstring wreplacement_str(1, wchar_t(BOOST_NOWIDE_REPLACEMENT_CHARACTE
 // clang-format off
 const utf8_to_wide roundtrip_tests[] = {
     {"", L""},
+    // Ascii
+    {"a", L"a"},
+    // 2 Octet
+    {"\xc3\xb1", L"\u00F1"},
+    // 3 Octet
+    {"\xe2\x82\xa1", L"\u20A1"},
+    // 4 Octet
+    {"\xf0\x90\x8c\xbc", L"\U0001033C"},
+    // Last valid codepoint
+    {"\xf4\x8f\xbf\xbf", L"\U0010FFFF"},
+    // Misc
     {"\xf0\x9d\x92\x9e-\xD0\xBF\xD1\x80\xD0\xB8\xD0\xB2\xD0\xB5\xD1\x82-\xE3\x82\x84\xE3\x81\x82.txt",
     L"\U0001D49E-\u043F\u0440\u0438\u0432\u0435\u0442-\u3084\u3042.txt"},
     {"\xd7\xa9-\xd0\xbc-\xce\xbd.txt",
@@ -42,6 +53,28 @@ const utf8_to_wide roundtrip_tests[] = {
 };
 
 const utf8_to_wide invalid_utf8_tests[] = {
+    // 2 Octet
+    {"\xc3\x28", L"\ufffd"},
+    {"\xa0\xa1", L"\ufffd\ufffd"},
+    // 3 Octet
+    {"\xe2\x28\xa1", L"\ufffd\ufffd"},
+    {"\xe2\x82\x28", L"\ufffd"},
+    // 4 Octet
+    {"\xf0\x28\x8c\xbc", L"\ufffd\ufffd\ufffd"},
+    {"\xf0\x90\x28\xbc", L"\ufffd\ufffd"},
+    {"\xf0\x90\x8c\x28", L"\ufffd"},
+    // 5 and 6 byte possible but invalid UTF
+    {"\xf8\xa1\xa1\xa1\xa1", L"\ufffd\ufffd\ufffd\ufffd\ufffd"},
+    {"\xfc\xa1\xa1\xa1\xa1\xa1", L"\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd"},
+    // First invalid codepoint
+    {"\xf4\x90\x80\x80", L"\ufffd\ufffd\ufffd\ufffd"},
+    // Overlong ascii (0x2F),
+    {"\xc0\xaf", L"\ufffd\ufffd"},
+    {"\xe0\x80\xaf", L"\ufffd\ufffd\ufffd"},
+    {"\xf0\x80\x80\xaf", L"\ufffd\ufffd\ufffd\ufffd"},
+    {"\xf8\x80\x80\x80\xaf", L"\ufffd\ufffd\ufffd\ufffd\ufffd"},
+    {"\xfc\x80\x80\x80\x80\xaf", L"\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd"},
+    // Misc
     {"\xFF\xFF", L"\ufffd\ufffd"},
     {"\xd7\xa9\xFF", L"\u05e9\ufffd"},
     {"\xd7", L"\ufffd"},
@@ -101,6 +134,7 @@ void run_all(std::wstring (*to_wide)(const std::string&), std::string (*to_narro
     for(size_t i = 0; i < array_size(invalid_utf8_tests); i++)
     {
         std::cout << "  Invalid UTF8  " << i << std::endl;
+        const auto f3 = to_wide(invalid_utf8_tests[i].utf8);
         TEST(to_wide(invalid_utf8_tests[i].utf8) == invalid_utf8_tests[i].wide);
     }
 

--- a/test/test_traits.cpp
+++ b/test/test_traits.cpp
@@ -7,14 +7,21 @@
 //
 
 #include <boost/nowide/detail/is_path.hpp>
+#include <boost/nowide/detail/is_string_container.hpp>
 
 #include "test.hpp"
 #include <iostream>
+#include <string>
 
 #ifdef __has_include
 #if __has_include(<version>)
 #include <version>
 #endif
+#endif
+
+#ifdef __cpp_lib_string_view
+#include <string_view>
+#define BOOST_NOWIDE_TEST_STD_STRINGVIEW
 #endif
 
 // Exclude apple as support there is target level specific -.-
@@ -27,8 +34,29 @@
 #include <boost/filesystem/path.hpp>
 #endif
 
+using boost::nowide::detail::is_string_container;
+static_assert(is_string_container<std::string>::value, "!");
+static_assert(is_string_container<std::wstring>::value, "!");
+static_assert(is_string_container<std::u16string>::value, "!");
+static_assert(is_string_container<std::u32string>::value, "!");
+static_assert(!is_string_container<int>::value, "!");
+
+using boost::nowide::detail::get_data_width;
+static_assert(get_data_width<std::string>::value == sizeof(char), "!");
+static_assert(get_data_width<std::wstring>::value == sizeof(wchar_t), "!");
+static_assert(get_data_width<std::u16string>::value == sizeof(char16_t), "!");
+static_assert(get_data_width<std::u32string>::value == sizeof(char32_t), "!");
+static_assert(get_data_width<int>::value == 0, "!");
+
 void test_main(int, char**, char**)
 {
+#ifdef BOOST_NOWIDE_TEST_STD_STRINGVIEW
+    std::cout << "Testing string_view" << std::endl;
+    static_assert(is_string_container<std::string_view>::value, "!");
+    static_assert(is_string_container<std::wstring_view>::value, "!");
+    static_assert(is_string_container<std::u16string_view>::value, "!");
+    static_assert(is_string_container<std::u32string_view>::value, "!");
+#endif
 #ifdef BOOST_NOWIDE_TEST_SFS_PATH
     std::cout << "Testing std::filesystem::path" << std::endl;
     static_assert(boost::nowide::detail::is_path<std::filesystem::path>::value, "!");

--- a/test/test_traits.cpp
+++ b/test/test_traits.cpp
@@ -35,27 +35,27 @@
 #endif
 
 using boost::nowide::detail::is_string_container;
-static_assert(is_string_container<std::string>::value, "!");
-static_assert(is_string_container<std::wstring>::value, "!");
-static_assert(is_string_container<std::u16string>::value, "!");
-static_assert(is_string_container<std::u32string>::value, "!");
-static_assert(!is_string_container<int>::value, "!");
+static_assert(is_string_container<std::string, true>::value, "!");
+static_assert(is_string_container<std::wstring, false>::value, "!");
+static_assert(is_string_container<std::u16string, false>::value, "!");
+static_assert(is_string_container<std::u32string, false>::value, "!");
+static_assert(!is_string_container<int, true>::value, "!");
+static_assert(!is_string_container<int, false>::value, "!");
 
 using boost::nowide::detail::get_data_width;
 static_assert(get_data_width<std::string>::value == sizeof(char), "!");
 static_assert(get_data_width<std::wstring>::value == sizeof(wchar_t), "!");
 static_assert(get_data_width<std::u16string>::value == sizeof(char16_t), "!");
 static_assert(get_data_width<std::u32string>::value == sizeof(char32_t), "!");
-static_assert(get_data_width<int>::value == 0, "!");
 
 void test_main(int, char**, char**)
 {
 #ifdef BOOST_NOWIDE_TEST_STD_STRINGVIEW
     std::cout << "Testing string_view" << std::endl;
-    static_assert(is_string_container<std::string_view>::value, "!");
-    static_assert(is_string_container<std::wstring_view>::value, "!");
-    static_assert(is_string_container<std::u16string_view>::value, "!");
-    static_assert(is_string_container<std::u32string_view>::value, "!");
+    static_assert(is_string_container<std::string_view, true>::value, "!");
+    static_assert(is_string_container<std::wstring_view, false>::value, "!");
+    static_assert(is_string_container<std::u16string_view, false>::value, "!");
+    static_assert(is_string_container<std::u32string_view, false>::value, "!");
 #endif
 #ifdef BOOST_NOWIDE_TEST_SFS_PATH
     std::cout << "Testing std::filesystem::path" << std::endl;


### PR DESCRIPTION
This adds generic support for `string_view` by providing a trait that detects `std::string`, `std::string_view` and similar classes (such as `boost::string_view` and `nostd::string_view`.

Closes #33