### PR TITLE
Fix possible invalid read operations

### DIFF
--- a/config/check_lfs_support.cpp
+++ b/config/check_lfs_support.cpp
@@ -14,7 +14,7 @@
 
 void check(FILE* f)
 {
-#if defined(_WIN32) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(__CYGWIN__) && !defined(__MINGW32__)
     (void)_fseeki64(f, 0, SEEK_CUR);
     (void)_ftelli64(f);
 #else

--- a/include/boost/nowide/filebuf.hpp
+++ b/include/boost/nowide/filebuf.hpp
@@ -96,17 +96,19 @@ namespace nowide {
             swap(owns_buffer_, rhs.owns_buffer_);
             swap(last_char_[0], rhs.last_char_[0]);
             swap(mode_, rhs.mode_);
+
             // Fixup last_char references
-            if(epptr() == rhs.last_char_)
-                setp(last_char_, last_char_);
-            if(egptr() == rhs.last_char_)
-                rhs.setg(last_char_, gptr() == rhs.last_char_ ? last_char_ : last_char_ + 1, last_char_ + 1);
-            if(rhs.epptr() == last_char_)
-                setp(rhs.last_char_, rhs.last_char_);
-            if(rhs.egptr() == rhs.last_char_)
+            if(pbase() == rhs.last_char_)
+                setp(last_char_, (pptr() == epptr()) ? last_char_ : last_char_ + 1);
+            if(eback() == rhs.last_char_)
+                setg(last_char_, (gptr() == rhs.last_char_) ? last_char_ : last_char_ + 1, last_char_ + 1);
+
+            if(rhs.pbase() == last_char_)
+                rhs.setp(rhs.last_char_, (rhs.pptr() == rhs.epptr()) ? rhs.last_char_ : rhs.last_char_ + 1);
+            if(rhs.eback() == last_char_)
             {
                 rhs.setg(rhs.last_char_,
-                         rhs.gptr() == last_char_ ? rhs.last_char_ : rhs.last_char_ + 1,
+                         (rhs.gptr() == last_char_) ? rhs.last_char_ : rhs.last_char_ + 1,
                          rhs.last_char_ + 1);
             }
         }
@@ -172,6 +174,8 @@ namespace nowide {
                 buffer_ = NULL;
                 owns_buffer_ = false;
             }
+            setg(0, 0, 0);
+            setp(0, 0);
             return res ? this : NULL;
         }
         ///
@@ -226,7 +230,7 @@ namespace nowide {
             if(n > 0)
             {
                 if(std::fwrite(pbase(), 1, n, file_) != n)
-                    return -1;
+                    return EOF;
                 setp(buffer_, buffer_ + buffer_size_);
                 if(c != EOF)
                 {

--- a/include/boost/nowide/filebuf.hpp
+++ b/include/boost/nowide/filebuf.hpp
@@ -275,7 +275,11 @@ namespace nowide {
                 return EOF;
             if(!stop_writing())
                 return EOF;
-            if(buffer_size_ == 0)
+            // In text mode we cannot use a buffer size of more than 1 (i.e. single char only)
+            // This is due to the need to seek back in case of a sync to "put back" unread chars.
+            // However determining the number of chars to seek back is impossible in case there are newlines
+            // as we cannot know if those were converted.
+            if(buffer_size_ == 0 || !(mode_ & std::ios_base::binary))
             {
                 const int c = std::fgetc(file_);
                 if(c == EOF)

--- a/src/filebuf.cpp
+++ b/src/filebuf.cpp
@@ -12,7 +12,7 @@
 #define BOOST_NOWIDE_FTELL ::ftell
 #define BOOST_NOWIDE_FSEEK ::fseek
 #define BOOST_NOWIDE_OFF_T long
-#elif defined(_WIN32) && !defined(__CYGWIN__)
+#elif defined(_WIN32) && !defined(__CYGWIN__) && !defined(__MINGW32__)
 #define BOOST_NOWIDE_FTELL _ftelli64
 #define BOOST_NOWIDE_FSEEK _fseeki64
 #define BOOST_NOWIDE_OFF_T int64_t

--- a/test/test_fstream.cpp
+++ b/test/test_fstream.cpp
@@ -554,9 +554,41 @@ void test_peek_sync_get(const char* filename)
     }
 }
 
+void test_swap(const char* filename, const char* filename2)
+{
+    {
+        nw::ofstream f(filename);
+        f << "02468" << std::endl;
+        f.close();
+        f.open(filename2);
+        f << "13579" << std::endl;
+    }
+    remove_file_at_exit _(filename);
+    remove_file_at_exit _2(filename2);
+
+    nw::ifstream f1(filename);
+    nw::ifstream f2(filename2);
+    TEST(f1);
+    TEST(f2);
+    while(f1 && f2)
+    {
+        const int curChar1 = f1.peek();
+        const int curChar2 = f2.peek();
+        f1.swap(f2);
+        TEST(f1.peek() == curChar2);
+        TEST(f2.peek() == curChar1);
+        if(curChar1 == std::char_traits<char>::eof() || curChar2 == std::char_traits<char>::eof())
+            break;
+        TEST(f1.get() == char(curChar2));
+        f1.swap(f2);
+        TEST(f1.get() == char(curChar1));
+    }
+}
+
 void test_main(int, char** argv, char**)
 {
     const std::string exampleFilename = std::string(argv[0]) + "-\xd7\xa9-\xd0\xbc-\xce\xbd.txt";
+    const std::string exampleFilename2 = std::string(argv[0]) + "-\xd7\xa9-\xd0\xbc-\xce\xbd 2.txt";
 
     std::cout << "Testing fstream" << std::endl;
     test_ofstream_creates_file(exampleFilename.c_str());
@@ -579,4 +611,5 @@ void test_main(int, char** argv, char**)
     std::cout << "Regression tests" << std::endl;
     test_getline_and_tellg(exampleFilename.c_str());
     test_peek_sync_get(exampleFilename.c_str());
+    test_swap(exampleFilename.c_str(), exampleFilename2.c_str());
 }


### PR DESCRIPTION
- Read text files char-by-char. Reduces performance but is correct even when using seek (also indirectly via tellg), fixes #126 
- Reset stream pointers in close to avoid a use-after-free
- Fix swap for single-char states