### PR TITLE
Stop defining `__MSVCRT_VERSION__`

### DIFF
--- a/include/boost/nowide/config.hpp
+++ b/include/boost/nowide/config.hpp
@@ -17,13 +17,6 @@
 
 //! @cond Doxygen_Suppress
 
-// MinGW32 requires a __MSVCRT_VERSION__ defined to make some functions available, e.g. _stat64
-// Hence define this here to target MSVC 7.0 which has the required functions and do it as early as possible
-// as including a system header might default this to 0x0600 which is to low
-#if defined(__MINGW32__) && !defined(__MSVCRT_VERSION__)
-#define __MSVCRT_VERSION__ 0x0700
-#endif
-
 #if defined(BOOST_ALL_DYN_LINK) || defined(BOOST_NOWIDE_DYN_LINK)
 #ifdef BOOST_NOWIDE_SOURCE
 #define BOOST_NOWIDE_DECL BOOST_SYMBOL_EXPORT

--- a/standalone/config.hpp
+++ b/standalone/config.hpp
@@ -11,13 +11,6 @@
 
 #include <boost/nowide/replacement.hpp>
 
-// MinGW32 requires a __MSVCRT_VERSION__ defined to make some functions available, e.g. _stat64
-// Hence define this here to target MSVC 7.0 which has the required functions and do it as early as possible
-// as including a system header might default this to 0x0600 which is to low
-#if defined(__MINGW32__) && !defined(__MSVCRT_VERSION__)
-#define __MSVCRT_VERSION__ 0x0700
-#endif
-
 #if(defined(__WIN32) || defined(_WIN32) || defined(WIN32)) && !defined(__CYGWIN__)
 #define NOWIDE_WINDOWS
 #endif


### PR DESCRIPTION
`__MSVCRT_VERSION__` is a mingw internal and shouldn't be set by the user.

Setting it to something different than the toolchain provided value means the
headers and crt wont match which can result in crashes and build errors.

This fixes the boost build when targeting ucrt.

Downstream issue for context: https://github.com/msys2/MINGW-packages/issues/8283