### PR TITLE
Increase fetch depth for coverage build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -151,9 +151,13 @@ for:
               choco install opencppcoverage
               Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
               OpenCppCoverage.exe --quiet --export_type cobertura:cobertura.xml `
-              --sources ${env:APPVEYOR_BUILD_FOLDER} --modules "$PWD" `
-              --cover_children --working_dir "$PWD" -- ctest -C Debug
-              bash codecov.sh -f cobertura.xml -n Appveyor -e APPVEYOR_BUILD_WORKER_IMAGE -X gcov -X search -Z -U "-s" -A "-s"
+                --sources ${env:APPVEYOR_BUILD_FOLDER} --modules "$PWD" `
+                --cover_children --working_dir "$PWD" -- ctest -C Debug
+              $commit = if ($env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT) { $env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT } else { $env:APPVEYOR_REPO_COMMIT }
+              bash codecov.sh -f cobertura.xml -n Appveyor -e APPVEYOR_BUILD_WORKER_IMAGE `
+                -C $commit `
+                -X gcov -X search -Z `
+                -U "-s" -A "-s"
             }
       # Build consumer example test
       - cmake --build . --config %configuration% --target install

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -41,6 +41,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        if: '!matrix.coverage'
+      - uses: actions/checkout@v2
+        if: 'matrix.coverage'
+        with:
+          fetch-depth: 0
 
       - name: Install packages
         if: matrix.install


### PR DESCRIPTION
Avoid error/Warning: "Issue detecting commit SHA. Please run actions/checkout with fetch-depth > 1 or set to 0"
This seems to lead to differing submissions between appveyor and GHA to codecov