### PR TITLE
Improve compatibility for recent MinGW-w64 and Cygwin compilers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 # Copyright 2020-2021 Peter Dimov
 # Copyright 2021 Andrey Semashev
 # Copyright 2021 Alexander Grund
+# Copyright 2022 James E. King III
 #
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
-
+---
 name: CI
 
 on:
@@ -13,7 +14,10 @@ on:
     branches:
       - master
       - develop
+      - bugfix/**
       - feature/**
+      - fix/**
+      - pr/**
 
 concurrency:
   group: ${{format('{0}:{1}', github.repository, github.ref)}}
@@ -66,13 +70,14 @@ jobs:
           - { compiler: clang-5.0, cxxstd: '03,11,14,1z',    os: ubuntu-18.04 }
           - { compiler: clang-6.0, cxxstd: '03,11,14,17',    os: ubuntu-18.04 }
           - { compiler: clang-7,   cxxstd: '03,11,14,17',    os: ubuntu-18.04 }
-            # Note: clang-8 does not fully support C++20, so it is not compatible with some libstdc++ versions in this mode
+          # Note: clang-8 does not fully support C++20, so it is not compatible with some libstdc++ versions in this mode
           - { compiler: clang-8,   cxxstd: '03,11,14,17,2a', os: ubuntu-18.04, install: 'clang-8 g++-7', gcc_toolchain: 7 }
           - { compiler: clang-9,   cxxstd: '03,11,14,17,2a', os: ubuntu-20.04 }
           - { compiler: clang-10,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
           - { compiler: clang-11,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
           - { compiler: clang-12,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
-            # libc++
+
+          # libc++
           - { compiler: clang-6.0, cxxstd: '03,11,14',       os: ubuntu-18.04, stdlib: libc++, install: 'clang-6.0 libc++-dev libc++abi-dev' }
           - { compiler: clang-12,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04, stdlib: libc++, install: 'clang-12 libc++-12-dev libc++abi-12-dev' }
           - { name: Clang w/ sanitizers, sanitize: yes,
@@ -96,23 +101,27 @@ jobs:
             if [ -n "${{matrix.container}}" ] && [ -f "/etc/debian_version" ]; then
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y sudo software-properties-common
-                # Need (newer) git
+                # Need (newer) git, and the older Ubuntu container may require requesting the key manually using port 80
+                apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E1DD270288B4E6030699E45FA1715D88E1DF1F24
                 for i in {1..${NET_RETRY_COUNT:-3}}; do sudo -E add-apt-repository -y ppa:git-core/ppa && break || sleep 10; done
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT update
                 apt-get -o Acquire::Retries=$NET_RETRY_COUNT install -y g++ python libpython-dev git
+            fi
+            # multiple job types are not compatible with ccache, they use "ccache: no" in the matrix
+            if [[ "${{ matrix.ccache }}" == "no" ]]; then
+                echo "B2_USE_CCACHE=0" >> $GITHUB_ENV
             fi
             git config --global pack.threads 0
             ! command -v cmake &> /dev/null || echo "B2_FLAGS=--nowide-enable-cmake" >> $GITHUB_ENV
 
       - uses: actions/checkout@v2
-        if: '!matrix.coverage'
-      - uses: actions/checkout@v2
-        if: 'matrix.coverage'
         with:
-          fetch-depth: 0
+          # For coverage builds fetch the whole history, else only 1 commit using a 'fake ternary'
+          fetch-depth: ${{ matrix.coverage && '0' || '1' }}
 
       - name: Cache ccache
         uses: actions/cache@v2
+        if: env.B2_USE_CCACHE
         with:
           path: ~/.ccache
           key: ${{matrix.os}}-${{matrix.container}}-${{matrix.compiler}}
@@ -123,6 +132,7 @@ jobs:
           repository: boostorg/boost-ci
           ref: master
           path: boost-ci-cloned
+
       - name: Get CI scripts folder
         run: |
             # Copy ci folder if not testing Boost.CI
@@ -167,6 +177,18 @@ jobs:
             mkdir -p "$GCC_TOOLCHAIN_ROOT/lib/gcc/$MULTIARCH_TRIPLET"
             ln -s "/usr/lib/gcc/$MULTIARCH_TRIPLET/${{matrix.gcc_toolchain}}" "$GCC_TOOLCHAIN_ROOT/lib/gcc/$MULTIARCH_TRIPLET/${{matrix.gcc_toolchain}}"
 
+      - name: Setup multiarch
+        if: matrix.multiarch
+        run: |
+          sudo apt-get install --no-install-recommends -y binfmt-support qemu-user-static
+          sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          git clone https://github.com/jeking3/bdde.git
+          echo "$(pwd)/bdde/bin/linux" >> ${GITHUB_PATH}
+          echo "BDDE_DISTRO=${{ matrix.distro }}" >> ${GITHUB_ENV}
+          echo "BDDE_EDITION=${{ matrix.edition }}" >> ${GITHUB_ENV}
+          echo "BDDE_ARCH=${{ matrix.arch }}" >> ${GITHUB_ENV}
+          echo "B2_WRAPPER=bdde" >> ${GITHUB_ENV}
+
       - name: Setup Boost
         env:
           B2_ADDRESS_MODEL: ${{matrix.address-model}}
@@ -181,6 +203,7 @@ jobs:
         run: ci/github/codecov.sh "setup"
 
       - name: Run tests
+        if: '!matrix.coverity'
         run: ci/build.sh
 
       - name: Run tests with simulated no LFS support
@@ -191,6 +214,69 @@ jobs:
       - name: Upload coverage
         if: matrix.coverage
         run: ci/codecov.sh "upload"
+
+      - name: Run coverity
+        if: matrix.coverity && github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'master')
+        run: ci/github/coverity.sh
+        env:
+          COVERITY_SCAN_NOTIFICATION_EMAIL: ${{ secrets.COVERITY_SCAN_NOTIFICATION_EMAIL }}
+          COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+
+  MSYS2:
+    defaults:
+      run:
+        shell: msys2 {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { sys: MINGW32, compiler: gcc, cxxstd: '03,11,17,20' }
+          - { sys: MINGW64, compiler: gcc, cxxstd: '03,11,17,20' }
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup MSYS2 environment
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.sys}}
+          update: true
+          install: git python
+          pacboy: gcc:p cmake:p ninja:p
+
+      - name: Fetch Boost.CI
+        uses: actions/checkout@v2
+        with:
+          repository: boostorg/boost-ci
+          ref: master
+          path: boost-ci-cloned
+      - name: Get CI scripts folder
+        run: |
+            # Copy ci folder if not testing Boost.CI
+            [[ "$GITHUB_REPOSITORY" =~ "boost-ci" ]] || cp -r boost-ci-cloned/ci .
+            rm -rf boost-ci-cloned
+
+      - name: Setup Boost
+        env:
+          B2_COMPILER: ${{matrix.compiler}}
+          B2_CXXSTD: ${{matrix.cxxstd}}
+          B2_SANITIZE: ${{matrix.sanitize}}
+          B2_STDLIB: ${{matrix.stdlib}}
+        run: ci/github/install.sh
+
+      - name: Run tests
+        run: ci/build.sh
+
+      # Run also the CMake tests to avoid having to setup another matrix for CMake on MSYS
+      - name: Run CMake tests
+        run: |
+            cd "$BOOST_ROOT"
+            mkdir __build_cmake_test__ && cd __build_cmake_test__
+            cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBOOST_INCLUDE_LIBRARIES=$SELF -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=ON -DBoost_VERBOSE=ON ..
+            cmake --build . --target tests --config Debug
+            ctest --output-on-failure --build-config Debug
 
   CMake:
     defaults:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -1,4 +1,4 @@
-# Copyright 2019 - 2021 Alexander Grund
+# Copyright 2019 - 2022 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE or copy at http://boost.org/LICENSE_1_0.txt)
 
@@ -31,7 +31,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest]
+        os: [ubuntu-18.04, windows-2019]
         buildType: [Debug, Release]
         standalone: [Boost, Standalone]
         shared_lib: [ON, OFF]

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -10,7 +10,10 @@ on:
     branches:
       - master
       - develop
+      - bugfix/**
       - feature/**
+      - fix/**
+      - pr/**
 
 concurrency:
   group: ${{format('ci_tests{0}:{1}', github.repository, github.ref)}}

--- a/include/boost/nowide/stat.hpp
+++ b/include/boost/nowide/stat.hpp
@@ -29,8 +29,8 @@ namespace nowide {
     using ::stat;
 #else
     /// \brief Typedef for the file info structure.
-    /// Able to hold 64 bit filesize and timestamps on Windows and usually also on other 64 Bit systems
-    /// This allows to write portable code with option LFS support
+    /// Able to hold 64 bit file size and timestamps on Windows and usually also on other 64 Bit systems
+    /// This allows to write portable code with optional LFS support
     typedef struct ::__stat64 stat_t;
     /// \brief Typedef for the file info structure used in the POSIX stat call
     /// Resolves to `struct _stat` on Windows and `struct stat` otherwise
@@ -39,8 +39,9 @@ namespace nowide {
 
     /// \cond INTERNAL
     namespace detail {
+        BOOST_NOWIDE_DECL int stat(const char* path, stat_t* buffer, size_t buffer_size);
         BOOST_NOWIDE_DECL int stat(const char* path, posix_stat_t* buffer, size_t buffer_size);
-    }
+    } // namespace detail
     /// \endcond
 
     ///
@@ -48,7 +49,10 @@ namespace nowide {
     ///
     /// Return information about a file from an UTF-8 encoded path
     ///
-    BOOST_NOWIDE_DECL int stat(const char* path, stat_t* buffer);
+    inline int stat(const char* path, stat_t* buffer)
+    {
+        return detail::stat(path, buffer, sizeof(*buffer));
+    }
     ///
     /// \brief UTF-8 aware stat function, returns 0 on success
     ///

--- a/src/cstdio.cpp
+++ b/src/cstdio.cpp
@@ -1,6 +1,6 @@
 //
 //  Copyright (c) 2012 Artyom Beilis (Tonkikh)
-//  Copyright (c) 2020 Alexander Grund
+//  Copyright (c) 2020-2022 Alexander Grund
 //
 //  Distributed under the Boost Software License, Version 1.0. (See
 //  accompanying file LICENSE or copy at
@@ -12,8 +12,11 @@
 #ifdef _MSC_VER
 #define _CRT_SECURE_NO_WARNINGS
 #elif defined(__MINGW32__) && defined(__STRICT_ANSI__)
-// Need the _w* functions which are extensions on MinGW
+// Need the _w* functions which are extensions on MinGW but not on MinGW-w64
+#include <_mingw.h>
+#ifndef __MINGW64_VERSION_MAJOR
 #undef __STRICT_ANSI__
+#endif
 #endif
 
 #include <boost/nowide/cstdio.hpp>

--- a/src/cstdio.cpp
+++ b/src/cstdio.cpp
@@ -11,8 +11,8 @@
 
 #ifdef _MSC_VER
 #define _CRT_SECURE_NO_WARNINGS
-#elif(defined(__MINGW32__) || defined(__CYGWIN__)) && defined(__STRICT_ANSI__)
-// Need the _w* functions which are extensions on MinGW/Cygwin
+#elif defined(__MINGW32__) && defined(__STRICT_ANSI__)
+// Need the _w* functions which are extensions on MinGW
 #undef __STRICT_ANSI__
 #endif
 

--- a/src/cstdlib.cpp
+++ b/src/cstdlib.cpp
@@ -11,9 +11,12 @@
 
 #ifdef _MSC_VER
 #define _CRT_SECURE_NO_WARNINGS
-#elif(defined(__MINGW32__) || defined(__CYGWIN__)) && defined(__STRICT_ANSI__)
-// Need the _w* functions which are extensions on MinGW/Cygwin
+#elif defined(__MINGW32__) && defined(__STRICT_ANSI__)
+// Need the _w* functions which are extensions on MinGW
 #undef __STRICT_ANSI__
+#elif defined(__CYGWIN__) && !defined(_GNU_SOURCE)
+// The setenv family of functions is an extension on Cygwin
+#define _GNU_SOURCE 1
 #endif
 
 #include <boost/nowide/cstdlib.hpp>

--- a/src/cstdlib.cpp
+++ b/src/cstdlib.cpp
@@ -1,6 +1,6 @@
 //
 //  Copyright (c) 2012 Artyom Beilis (Tonkikh)
-//  Copyright (c) 2020 Alexander Grund
+//  Copyright (c) 2020-2022 Alexander Grund
 //
 //  Distributed under the Boost Software License, Version 1.0. (See
 //  accompanying file LICENSE or copy at
@@ -12,8 +12,11 @@
 #ifdef _MSC_VER
 #define _CRT_SECURE_NO_WARNINGS
 #elif defined(__MINGW32__) && defined(__STRICT_ANSI__)
-// Need the _w* functions which are extensions on MinGW
+// Need the _w* functions which are extensions on MinGW but not on MinGW-w64
+#include <_mingw.h>
+#ifndef __MINGW64_VERSION_MAJOR
 #undef __STRICT_ANSI__
+#endif
 #elif defined(__CYGWIN__) && !defined(_GNU_SOURCE)
 // The setenv family of functions is an extension on Cygwin
 #define _GNU_SOURCE 1
@@ -21,7 +24,7 @@
 
 #include <boost/nowide/cstdlib.hpp>
 
-#if !defined(BOOST_WINDOWS)
+#ifndef BOOST_WINDOWS
 namespace boost {
 namespace nowide {
     int setenv(const char* key, const char* value, int overwrite)

--- a/src/stat.cpp
+++ b/src/stat.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2020 Alexander Grund
+//  Copyright (c) 2020-2022 Alexander Grund
 //
 //  Distributed under the Boost Software License, Version 1.0. (See
 //  accompanying file LICENSE or copy at  http://www.boost.org/LICENSE_1_0.txt)
@@ -8,13 +8,16 @@
 #define BOOST_NOWIDE_SOURCE
 
 #if defined(__MINGW32__) && defined(__STRICT_ANSI__)
-// Need the _w* functions which are extensions on MinGW
+// Need the _w* functions which are extensions on MinGW but not on MinGW-w64
+#include <_mingw.h>
+#ifndef __MINGW64_VERSION_MAJOR
 #undef __STRICT_ANSI__
+#endif
 #endif
 
 #include <boost/nowide/config.hpp>
 
-#if defined(BOOST_WINDOWS)
+#ifdef BOOST_WINDOWS
 
 #include <boost/nowide/stackstring.hpp>
 #include <boost/nowide/stat.hpp>

--- a/src/stat.cpp
+++ b/src/stat.cpp
@@ -7,8 +7,8 @@
 
 #define BOOST_NOWIDE_SOURCE
 
-#if(defined(__MINGW32__) || defined(__CYGWIN__)) && defined(__STRICT_ANSI__)
-// Need the _w* functions which are extensions on MinGW/Cygwin
+#if defined(__MINGW32__) && defined(__STRICT_ANSI__)
+// Need the _w* functions which are extensions on MinGW
 #undef __STRICT_ANSI__
 #endif
 

--- a/src/stat.cpp
+++ b/src/stat.cpp
@@ -36,12 +36,17 @@ namespace nowide {
             const wstackstring wpath(path);
             return _wstat(wpath.get(), buffer);
         }
+        int stat(const char* path, stat_t* buffer, size_t buffer_size)
+        {
+            if(sizeof(*buffer) != buffer_size)
+            {
+                errno = EINVAL;
+                return EINVAL;
+            }
+            const wstackstring wpath(path);
+            return _wstat64(wpath.get(), buffer);
+        }
     } // namespace detail
-    int stat(const char* path, stat_t* buffer)
-    {
-        const wstackstring wpath(path);
-        return _wstat64(wpath.get(), buffer);
-    }
 } // namespace nowide
 } // namespace boost
 

--- a/test/test_stat.cpp
+++ b/test/test_stat.cpp
@@ -62,6 +62,10 @@ void test_main(int, char** argv, char**)
         // Need to use the detail function directly
         TEST_EQ(boost::nowide::detail::stat(filename.c_str(), &stdStat, sizeof(stdStat) - 4u), EINVAL);
         TEST_EQ(errno, EINVAL);
+        // Same for our stat_t
+        boost::nowide::stat_t boostStat;
+        TEST_EQ(boost::nowide::detail::stat(filename.c_str(), &boostStat, sizeof(boostStat) - 4u), EINVAL);
+        TEST_EQ(errno, EINVAL);
     }
 #endif
 


### PR DESCRIPTION
On e.g. GCC 11 used in recent MinGW-w64 and Cygwin environments undefining `__STRICT_ANSI__` is no longer supported.

However this is only required for the MinGW compilers, not the MinGW-w64 ones or on Cygwin.

Fixes #146 

- Add CI for MSYS2 using a MinGW-w64 GCC 11 compiler reproducing #146
- Add CI for more recent Cygwin to avoid regressions
- Differentiate between MinGW and MinGW-w64 as the latter does not require the `__STRICT_ANSI__` handling
- Improve `stat` function to detect differences in the struct definition between compiling and using the library
- Enable the required extension functions on Cygwin via `_GNU_SOURCE`, not by touching `__STRICT_ANSI__`
- Fix search paths for relative includes