### PR TITLE
Fix missing standalone define

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -95,7 +95,13 @@ jobs:
         mkdir build
     - name: Configure
       working-directory: build
-      run: cmake -DBoost_DEBUG=ON -DCMAKE_BUILD_TYPE=${{matrix.buildType}} -DBUILD_SHARED_LIBS=${{matrix.shared_lib}} -DCMAKE_INSTALL_PREFIX=~/.local -G "${{matrix.generator}}" -DBoost_NO_BOOST_CMAKE=ON ..
+      run: |
+        extraFlags="-DBoost_DEBUG=ON -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_INSTALL_PREFIX=~/.local"
+        if ! [[ "${{matrix.generator}}" =~ "Visual Studio" ]]; then
+          # Enable warning to find missing defines, especially important for the standalone version
+          extraFlags="$extraFlags -DCMAKE_CXX_FLAGS=-Wundef"
+        fi
+        cmake -DCMAKE_BUILD_TYPE=${{matrix.buildType}} -DBUILD_SHARED_LIBS=${{matrix.shared_lib}} -G "${{matrix.generator}}" $extraFlags ..
     - name: Build & Install
       run: cmake --build build --config ${{matrix.buildType}} --target install
 

--- a/include/boost/nowide/config.hpp
+++ b/include/boost/nowide/config.hpp
@@ -49,30 +49,34 @@
 //! @endcond
 
 /// @def BOOST_NOWIDE_USE_WCHAR_OVERLOADS
-/// @brief Whether to use the wchar_t* overloads in fstream/filebuf
-/// Enabled on Windows and Cygwin as the latter may use wchar_t in filesystem::path
-#if defined(BOOST_WINDOWS) || defined(__CYGWIN__)
+/// @brief Whether to use the wchar_t* overloads in fstream-classes.
+///
+/// Enabled by default on Windows and Cygwin as the latter may use wchar_t in filesystem::path.
+#ifndef BOOST_NOWIDE_USE_WCHAR_OVERLOADS
+#if defined(BOOST_WINDOWS) || defined(__CYGWIN__) || defined(BOOST_NOWIDE_DOXYGEN)
 #define BOOST_NOWIDE_USE_WCHAR_OVERLOADS 1
 #else
 #define BOOST_NOWIDE_USE_WCHAR_OVERLOADS 0
 #endif
+#endif
 
 /// @def BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT
-/// @brief Define to 1 to use internal class from filebuf.hpp
+/// @brief Define to 1 to use the class from <filebuf.hpp> that is used on Windows.
 ///
-/// - On Non-Windows platforms: Define to 1 to use the same class from header <filebuf.hpp>
-///   that is used on Windows.
 /// - On Windows: No effect, always overwritten to 1
+/// - Others (including Cygwin): Defaults to the value of #BOOST_NOWIDE_USE_WCHAR_OVERLOADS if not set.
+///
+/// When set to 0 boost::nowide::basic_filebuf will be an alias for std::basic_filebuf.
 ///
 /// Affects boost::nowide::basic_filebuf,
 /// boost::nowide::basic_ofstream, boost::nowide::basic_ifstream, boost::nowide::basic_fstream
-#if defined(BOOST_WINDOWS) || BOOST_NOWIDE_USE_WCHAR_OVERLOADS
+#if defined(BOOST_WINDOWS) || defined(BOOST_NOWIDE_DOXYGEN)
 #ifdef BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT
 #undef BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT
 #endif
 #define BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT 1
 #elif !defined(BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT)
-#define BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT 0
+#define BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT BOOST_NOWIDE_USE_WCHAR_OVERLOADS
 #endif
 
 //! @cond Doxygen_Suppress

--- a/include/boost/nowide/config.hpp
+++ b/include/boost/nowide/config.hpp
@@ -1,6 +1,6 @@
 //
 //  Copyright (c) 2012 Artyom Beilis (Tonkikh)
-//  Copyright (c) 2019 - 2020 Alexander Grund
+//  Copyright (c) 2019 - 2022 Alexander Grund
 //
 //  Distributed under the Boost Software License, Version 1.0. (See
 //  accompanying file LICENSE or copy at
@@ -27,9 +27,7 @@
 #define BOOST_NOWIDE_DECL
 #endif // BOOST_NOWIDE_DYN_LINK
 
-//
 // Automatically link to the correct build variant where possible.
-//
 #if !defined(BOOST_ALL_NO_LIB) && !defined(BOOST_NOWIDE_NO_LIB) && !defined(BOOST_NOWIDE_SOURCE)
 //
 // Set the name of our library, this will get undef'ed by auto_link.hpp
@@ -79,7 +77,7 @@
 
 //! @cond Doxygen_Suppress
 
-#if BOOST_VERSION < 106500 && defined(BOOST_GCC) && __GNUC__ >= 7
+#if BOOST_VERSION < 106500 && defined(__GNUC__) && __GNUC__ >= 7
 #define BOOST_NOWIDE_FALLTHROUGH __attribute__((fallthrough))
 #else
 #define BOOST_NOWIDE_FALLTHROUGH BOOST_FALLTHROUGH
@@ -115,4 +113,4 @@ namespace boost {
 namespace nowide {}
 } // namespace boost
 
-#endif // boost/nowide/config.hpp
+#endif

--- a/include/boost/nowide/filebuf.hpp
+++ b/include/boost/nowide/filebuf.hpp
@@ -38,9 +38,10 @@ namespace nowide {
     using std::filebuf;
 #else // Windows
     ///
-    /// \brief This forward declaration defines the basic_filebuf type.
+    /// \brief This forward declaration defines the basic_filebuf type
+    ///        which is used when #BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT is set, e.g. on Windows.
     ///
-    /// it is implemented and specialized for CharType = char, it
+    /// It is implemented and specialized for CharType = char, it
     /// implements std::filebuf over standard C I/O
     ///
     template<typename CharType, typename Traits = std::char_traits<CharType>>
@@ -48,8 +49,9 @@ namespace nowide {
 
     ///
     /// \brief This is the implementation of std::filebuf
+    ///        which is used when #BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT is set, e.g. on Windows.
     ///
-    /// it is implemented and specialized for CharType = char, it
+    /// It is implemented and specialized for CharType = char, it
     /// implements std::filebuf over standard C I/O
     ///
     template<>

--- a/include/boost/nowide/fstream.hpp
+++ b/include/boost/nowide/fstream.hpp
@@ -68,6 +68,7 @@ namespace nowide {
     ///
     /// \brief Same as std::basic_ifstream<char> but accepts UTF-8 strings under Windows
     ///
+    /// Affected by #BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT and #BOOST_NOWIDE_USE_WCHAR_OVERLOADS
     template<typename CharType, typename Traits = std::char_traits<CharType>>
     class basic_ifstream : public detail::fstream_impl<CharType, Traits, detail::StreamTypeIn>
     {
@@ -118,7 +119,7 @@ namespace nowide {
     ///
     /// \brief Same as std::basic_ofstream<char> but accepts UTF-8 strings under Windows
     ///
-
+    /// Affected by #BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT and #BOOST_NOWIDE_USE_WCHAR_OVERLOADS
     template<typename CharType, typename Traits = std::char_traits<CharType>>
     class basic_ofstream : public detail::fstream_impl<CharType, Traits, detail::StreamTypeOut>
     {
@@ -171,6 +172,7 @@ namespace nowide {
     ///
     /// \brief Same as std::basic_fstream<char> but accepts UTF-8 strings under Windows
     ///
+    /// Affected by #BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT and #BOOST_NOWIDE_USE_WCHAR_OVERLOADS
     template<typename CharType, typename Traits = std::char_traits<CharType>>
     class basic_fstream : public detail::fstream_impl<CharType, Traits, detail::StreamTypeInOut>
     {

--- a/standalone/config.hpp
+++ b/standalone/config.hpp
@@ -1,22 +1,19 @@
 //
 //  Copyright (c) 2012 Artyom Beilis (Tonkikh)
-//  Copyright (c) 2020 Alexander Grund
+//  Copyright (c) 2020 - 2022 Alexander Grund
 //
 //  Distributed under the Boost Software License, Version 1.0. (See
 //  accompanying file LICENSE or copy at
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
-#ifndef NOWIDE_CONFIG_HPP_INCLUDED
-#define NOWIDE_CONFIG_HPP_INCLUDED
+// Defines macros which otherwise get defined by including <boost/config.hpp>
 
-#include <boost/nowide/replacement.hpp>
-
-#if(defined(__WIN32) || defined(_WIN32) || defined(WIN32)) && !defined(__CYGWIN__)
-#define NOWIDE_WINDOWS
+#if(defined(_WIN32) || defined(__WIN32__) || defined(WIN32)) && !defined(__CYGWIN__)
+#define BOOST_WINDOWS
 #endif
 
 #ifdef _MSC_VER
-#define NOWIDE_MSVC _MSC_VER
+#define BOOST_MSVC _MSC_VER
 #endif
 
 #ifdef __GNUC__
@@ -27,41 +24,15 @@
 #define BOOST_SYMBOL_VISIBLE
 #endif
 
-#ifdef NOWIDE_WINDOWS
+#ifdef BOOST_WINDOWS
 #define BOOST_SYMBOL_EXPORT __declspec(dllexport)
 #define BOOST_SYMBOL_IMPORT __declspec(dllimport)
+#elif defined(__CYGWIN__) && defined(__GNUC__) && (__GNUC__ >= 4)
+#define BOOST_SYMBOL_EXPORT __attribute__((__dllexport__))
+#define BOOST_SYMBOL_IMPORT __attribute__((__dllimport__))
 #else
 #define BOOST_SYMBOL_EXPORT BOOST_SYMBOL_VISIBLE
 #define BOOST_SYMBOL_IMPORT
-#endif
-
-#if defined(BOOST_NOWIDE_DYN_LINK)
-#ifdef BOOST_NOWIDE_SOURCE
-#define BOOST_NOWIDE_DECL BOOST_SYMBOL_EXPORT
-#else
-#define BOOST_NOWIDE_DECL BOOST_SYMBOL_IMPORT
-#endif // BOOST_NOWIDE_SOURCE
-#else
-#define BOOST_NOWIDE_DECL
-#endif // BOOST_NOWIDE_DYN_LINK
-
-#ifndef NOWIDE_DECL
-#define NOWIDE_DECL
-#endif
-
-#if defined(NOWIDE_WINDOWS)
-#ifdef BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT
-#undef BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT
-#endif
-#define BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT 1
-#elif !defined(BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT)
-#define BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT 0
-#endif
-
-#if defined(__GNUC__) && __GNUC__ >= 7
-#define BOOST_NOWIDE_FALLTHROUGH __attribute__((fallthrough))
-#else
-#define BOOST_NOWIDE_FALLTHROUGH
 #endif
 
 #if defined __GNUC__
@@ -74,24 +45,4 @@
 #if !defined(BOOST_UNLIKELY)
 #define BOOST_UNLIKELY(x) x
 #endif
-#endif
-
-// The std::codecvt<char16/32_t, char, std::mbstate_t> are deprecated in C++20
-// These macros can suppress this warning
-#if defined(_MSC_VER)
-#define BOOST_NOWIDE_SUPPRESS_UTF_CODECVT_DEPRECATION_BEGIN __pragma(warning(push)) __pragma(warning(disable : 4996))
-#define BOOST_NOWIDE_SUPPRESS_UTF_CODECVT_DEPRECATION_END __pragma(warning(pop))
-#elif(__cplusplus >= 202002L) && defined(__clang__)
-#define BOOST_NOWIDE_SUPPRESS_UTF_CODECVT_DEPRECATION_BEGIN \
-    _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
-#define BOOST_NOWIDE_SUPPRESS_UTF_CODECVT_DEPRECATION_END _Pragma("clang diagnostic pop")
-#elif(__cplusplus >= 202002L) && defined(__GNUC__)
-#define BOOST_NOWIDE_SUPPRESS_UTF_CODECVT_DEPRECATION_BEGIN \
-    _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#define BOOST_NOWIDE_SUPPRESS_UTF_CODECVT_DEPRECATION_END _Pragma("GCC diagnostic pop")
-#else
-#define BOOST_NOWIDE_SUPPRESS_UTF_CODECVT_DEPRECATION_BEGIN
-#define BOOST_NOWIDE_SUPPRESS_UTF_CODECVT_DEPRECATION_END
-#endif
-
 #endif

--- a/test/test_stdio.cpp
+++ b/test/test_stdio.cpp
@@ -43,7 +43,7 @@ void create_test_file(const std::string& filename)
     std::fclose(f);
 }
 
-#if BOOST_MSVC
+#ifdef BOOST_MSVC
 #include <crtdbg.h> // For _CrtSetReportMode
 void noop_invalid_param_handler(const wchar_t*, const wchar_t*, const wchar_t*, unsigned, uintptr_t)
 {} // LCOV_EXCL_LINE
@@ -54,7 +54,7 @@ void test_main(int, char** argv, char**)
 {
     const std::string prefix = argv[0];
     const std::string filename = prefix + "\xd7\xa9-\xd0\xbc-\xce\xbd.txt";
-#if BOOST_MSVC
+#ifdef BOOST_MSVC
     // Prevent abort on freopen(NULL, ...)
     _set_invalid_parameter_handler(noop_invalid_param_handler);
 #endif

--- a/tools/create_standalone.sh
+++ b/tools/create_standalone.sh
@@ -29,9 +29,25 @@ mkdir -p "$targetFolder"/include
 
 cp -r include/boost/nowide "$targetFolder"/include
 cp -r config src test cmake CMakeLists.txt LICENSE README.md "$targetFolder"
-cp standalone/*.hpp "$targetFolder"/include/nowide
 mv "$targetFolder/cmake/BoostAddWarnings.cmake" "$targetFolder/cmake/NowideAddWarnings.cmake"
 find "$targetFolder" -name 'Jamfile*' -delete
+
+# Stitch config header together
+# Remove the boost headers, the important parts of config.hpp will be put in later
+config_hpp="$targetFolder/include/nowide/config.hpp"
+sed -E '/<boost\/[a-z_]+\.hpp>/d' -i "$config_hpp"
+# Put config replacement header below the doxygen marker
+lineTarget=$(grep -m 1 -n '//! @cond Doxygen_Suppress' "$config_hpp" | cut -d ":" -f 1)
+lineSrc=$(grep -n 'boost/config.hpp' "standalone/config.hpp" | cut -d ":" -f 1) # Skip the file header
+{ head -n $lineTarget "$config_hpp"; tail -n +$((lineSrc+2)) standalone/config.hpp; tail -n +$((lineTarget+1)) "$config_hpp"; } > "$config_hpp".new
+mv "$config_hpp".new "$config_hpp"
+sed -e '/Automatically link/,/auto-linking disabled/d' \
+    -e 's/defined(BOOST_ALL_DYN_LINK) || //' \
+    -e '/namespace boost/d' \
+    -e 's/ BOOST_FALLTHROUGH//' \
+    -i "$config_hpp"
+sed -E 's/BOOST_VERSION . [0-9]+ && //g' -i "$config_hpp" # Checks against BOOST_VERSION
+
 
 SOURCES=$(find "$targetFolder" -name '*.hpp' -or -name '*.cpp')
 SOURCES_NO_BOOST=$(echo "$SOURCES" | grep -v 'filesystem.hpp')


### PR DESCRIPTION
This basically generates the standalone config.hpp from the regular config.hpp by pasting the required defines otherwise coming from `<boost/config.hpp>` into the appropriate place.

This avoids the standalone config becoming out of sync with the main one which e.g. resulted in a missing `NOWIDE_USE_WCHAR_OVERLOADS`.
This is now checked on CI by compiling (some builds) with `-Wundef` as was actually intended.

As a side effect Cygwin builds using the standalone version will use the custom filebuf implementation just as they do using the Boost version. This is due to Cygwin also using `wchar_t*` for paths which requires enabling those overloads which requires the custom filebuf.
To be exact: This is until C++17 which adds `wchar_t*` overloads to `filebuf::open` in that case, but when using C++17 and `std::filesystem::path` you'd probably want to use the `std` variants of `<fstream>` anyway.   
To remediate this allow users to overwrite `NOWIDE_USE_WCHAR_OVERLOADS` and default `NOWIDE_USE_FILEBUF_REPLACEMENT` to that allowing to overwrite this too except for (native, i.e. not Cygwin) Windows platforms.

Note that while those knobs are provided not all possible configurations are actually tested and it is the users task to ensure that those defines are set in all used compilation units or there may be ODR violations. It is hence strongly advised to not change the defaults.