### PR TITLE
Fix MSYS2 builds

### DIFF
--- a/test/test_codecvt.cpp
+++ b/test/test_codecvt.cpp
@@ -334,7 +334,7 @@ void test_codecvt_err()
         char* to = buf;
         char* to_end = buf + 32;
         char* to_next = to;
-        wchar_t err_buf[3] = {'1', 0xDC9E, 0}; // second surrogate not works both for UTF-16 and 32
+        wchar_t err_buf[] = {'1', 0xDC9E, 0}; // second value is invalid for UTF-16 and 32
         const wchar_t* err_utf = err_buf;
         {
             std::mbstate_t mb{};
@@ -344,7 +344,7 @@ void test_codecvt_err()
             TEST_EQ(cvt.out(mb, from, from_end, from_next, to, to_end, to_next), cvt_type::ok);
             TEST(from_next == from + 2);
             TEST(to_next == to + 4);
-            TEST_EQ(std::string(to, to_next), "1" + boost::nowide::narrow(wreplacement_str));
+            TEST_EQ(std::string(to, to_next), boost::nowide::narrow(err_buf));
         }
     }
 }

--- a/test/test_system.cpp
+++ b/test/test_system.cpp
@@ -120,10 +120,10 @@ void run_child(int argc, char** argv, char** env)
     std::cout << "Subprocess ok" << std::endl;
 }
 
-void run_parent(const char* exe_path)
+void run_parent(const std::string& exe_path)
 {
     TEST(boost::nowide::system(nullptr) != 0);
-    const std::string command = "\"" + std::string(exe_path) + "\" " + example;
+    const std::string command = "\"" + exe_path + "\" " + example;
 #if BOOST_NOWIDE_TEST_USE_NARROW
     TEST_EQ(boost::nowide::setenv("BOOST_NOWIDE_TEST", example.c_str(), 1), 0);
     TEST_EQ(boost::nowide::setenv("BOOST_NOWIDE_TEST_NONE", example.c_str(), 1), 0);


### PR DESCRIPTION
GCC triggers a false positive:

> D:/a/_temp/msys64/mingw32/include/c++/12.1.0/bits/char_traits.h:431:56: error: 'void* __builtin_memcpy(void*, const void*, unsigned int)' accessing 2147483650 or more bytes at offsets [2, 2147483647] and 1 overlaps 2147483653 bytes at offset -3 [-Werror=restrict]