### PR TITLE
Fix build on recent Cygwins

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -89,6 +89,13 @@ environment:
       B2_CXXSTD: 03,11,14,1z
       B2_TOOLSET: gcc
 
+    - FLAVOR: cygwin (64-bit, latest)
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      ADDPATH: C:\cygwin64\bin;
+      B2_ADDRESS_MODEL: 64
+      B2_CXXSTD: 03,11,14,1z
+      B2_TOOLSET: gcc
+
     - FLAVOR: mingw32
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       B2_ADDRESS_MODEL: 32

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -37,6 +37,7 @@ local SOURCES = console_buffer cstdio cstdlib filebuf iostream stat ;
 
 lib boost_nowide
   : $(SOURCES).cpp
+  : <include>../src
   ;
 
 boost-install boost_nowide ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -2,7 +2,7 @@
 
 # Copyright (c) 2003, 2006 Beman Dawes
 # Copyright (c) 2012 Artyom Beilis (Tonkikh)
-# Copyright (c) 2020-2021 Alexander Grund
+# Copyright (c) 2020-2022 Alexander Grund
 # 
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE or www.boost.org/LICENSE_1_0.txt)
@@ -23,6 +23,7 @@ rule require-windows ( properties * )
 
 project : requirements
   <library>/boost/nowide//boost_nowide
+  <include>.
   <warnings>pedantic
   <warnings-as-errors>on
   [ requires


### PR DESCRIPTION
Recent Cygwin where the current source files path is not added to the search path automatically fail to build without manually adding the include paths to relative includes