### PR TITLE
Fix coverity build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -202,22 +202,16 @@ for:
       - cd build
       - cmake -G "%GENERATOR%" ..
       - ps: |
-            nuget install -ExcludeVersion PublishCoverity
             cov-configure --msvc
-            cov-build.exe --dir cov-int cmake --build . --config $env:configuration
+            cov-build --dir cov-int cmake --build . --config $env:configuration
             If ($LastExitCode -ne 0) {
               cat cov-int/build-log.txt
               $host.SetShouldExit($LastExitCode)
             }
-            PublishCoverity\tools\PublishCoverity.exe compress --nologo -i cov-int -o cov-int.zip --overwrite
-
-            # This may fail due to a wrong HTTP 500 code from coverity, hence the stderr redirection via cmd
-            # to make the build succeed anyway
-            cmd /c PublishCoverity\tools\PublishCoverity.exe publish --nologo `
-              -t "$env:COVERITY_SCAN_TOKEN" `
-              -e "$env:COVERITY_SCAN_NOTIFICATION_EMAIL" `
-              -r "$env:APPVEYOR_REPO_NAME" `
-              -z "cov-int.zip" `
-              -d "Appveyor build for $env:APPVEYOR_REPO_BRANCH" `
-              --codeVersion "$env:APPVEYOR_REPO_BRANCH" 2`>`&1
-            Write-Host "Done"
+            7z a -tzip cov-int.zip cov-int
+            curl.exe --form token="$env:COVERITY_SCAN_TOKEN" `
+                     --form email="$env:COVERITY_SCAN_NOTIFICATION_EMAIL" `
+                     --form file=@cov-int.zip `
+                     --form version="$env:APPVEYOR_REPO_BRANCH" `
+                     --form description="Appveyor build for $env:APPVEYOR_REPO_BRANCH" `
+                     https://scan.coverity.com/builds?project=$env:APPVEYOR_REPO_NAME

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -209,9 +209,14 @@ for:
               $host.SetShouldExit($LastExitCode)
             }
             7z a -tzip cov-int.zip cov-int
-            curl.exe --form token="$env:COVERITY_SCAN_TOKEN" `
+            curl.exe --fail --silent --show-error `
+                     --form token="$env:COVERITY_SCAN_TOKEN" `
                      --form email="$env:COVERITY_SCAN_NOTIFICATION_EMAIL" `
                      --form file=@cov-int.zip `
                      --form version="$env:APPVEYOR_REPO_BRANCH" `
                      --form description="Appveyor build for $env:APPVEYOR_REPO_BRANCH" `
                      https://scan.coverity.com/builds?project=$env:APPVEYOR_REPO_NAME
+            If ($LastExitCode -ne 0) {
+              echo "Upload failed"
+              $host.SetShouldExit($LastExitCode)
+            }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -143,6 +143,7 @@ environment:
     - COVERITY: true
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: Visual Studio 16 2019
+      configuration: Debug
       BOOST_ROOT: C:\Libraries\boost_1_77_0
       COVERITY_SCAN_TOKEN:
         secure: FzhGUr+AR/VOBGUta7dDLMDruolChnvyMSvsM/zLvPY=
@@ -202,6 +203,7 @@ for:
       - cmake -G "%GENERATOR%" ..
       - ps: |
             nuget install -ExcludeVersion PublishCoverity
+            cov-configure --msvc
             cov-build.exe --dir cov-int cmake --build . --config $env:configuration
             If ($LastExitCode -ne 0) {
               cat cov-int/build-log.txt

--- a/include/boost/nowide/filebuf.hpp
+++ b/include/boost/nowide/filebuf.hpp
@@ -277,6 +277,7 @@ namespace nowide {
             if(!(mode_ & (std::ios_base::out | std::ios_base::app)) || !stop_reading())
                 return 0;
 
+            assert(n >= 0);
             // First empty the remaining put area, if any
             const char* const base = pbase();
             const size_t num_buffered = pptr() - base;
@@ -323,6 +324,7 @@ namespace nowide {
                 return std::basic_streambuf<char>::xsgetn(s, n);
             if(!(mode_ & std::ios_base::in) || !stop_writing())
                 return 0;
+            assert(n >= 0);
             std::streamsize num_copied = 0;
             // First empty the remaining get area, if any
             const auto num_buffered = egptr() - gptr();

--- a/test/benchmark_fstream.cpp
+++ b/test/benchmark_fstream.cpp
@@ -279,7 +279,7 @@ int main(int argc, char** argv)
     try
     {
         test_perf(filename.c_str());
-    } catch(const std::runtime_error& err)
+    } catch(const std::exception& err)
     {
         std::cerr << "Benchmarking failed: " << err.what() << std::endl;
         return 1;

--- a/test/test_codecvt.cpp
+++ b/test/test_codecvt.cpp
@@ -411,7 +411,7 @@ void test_codecvt_subst()
     run_all(codecvt_to_wide, codecvt_to_narrow);
 }
 
-// coverity [root_function]
+// coverity[root_function]
 void test_main(int, char**, char**)
 {
     test_codecvt_basic();

--- a/test/test_convert.cpp
+++ b/test/test_convert.cpp
@@ -127,7 +127,7 @@ std::string narrow_string_view(const std::wstring& s)
 }
 #endif
 
-// coverity [root_function]
+// coverity[root_function]
 void test_main(int, char**, char**)
 {
     std::string hello = "\xd7\xa9\xd7\x9c\xd7\x95\xd7\x9d";

--- a/test/test_env.cpp
+++ b/test/test_env.cpp
@@ -14,7 +14,7 @@
 #include <windows.h>
 #endif
 
-// coverity [root_function]
+// coverity[root_function]
 void test_main(int, char**, char**)
 {
     std::string example = "\xd7\xa9-\xd0\xbc-\xce\xbd";

--- a/test/test_filebuf.cpp
+++ b/test/test_filebuf.cpp
@@ -314,7 +314,9 @@ void test_xsgetn(const std::string& filepath, bool binary)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wrestrict"
 #endif
+        // coverity[negative_returns]
         TEST_EQ(buf.sgetn(&str[0], -1), 0);
+        // coverity[negative_returns]
         TEST_EQ(buf.sgetn(&str[0], -999), 0);
 #if defined(__GNUC__) && __GNUC__ >= 12
 #pragma GCC diagnostic pop
@@ -375,7 +377,9 @@ void test_xsputn(const std::string& filepath, bool binary)
             TEST(open_with_buffer(buf, filepath, make_mode(std::ios_base::out | std::ios_base::trunc, binary), buffer));
 
         TEST_EQ(buf.sputn(data.data(), 0), 0);
+        // coverity[negative_returns]
         TEST_EQ(buf.sputn(data.data(), -1), 0);
+        // coverity[negative_returns]
         TEST_EQ(buf.sputn(data.data(), -999), 0);
         buf.close();
         // No write when closed

--- a/test/test_filebuf.cpp
+++ b/test/test_filebuf.cpp
@@ -798,7 +798,7 @@ void test_swap(const std::string& filepath)
     }
 }
 
-// coverity [root_function]
+// coverity[root_function]
 void test_main(int, char** argv, char**)
 {
     const std::string exampleFilename = std::string(argv[0]) + "-\xd7\xa9-\xd0\xbc-\xce\xbd.txt";

--- a/test/test_fs.cpp
+++ b/test/test_fs.cpp
@@ -21,7 +21,7 @@
 #endif
 #include <boost/filesystem/operations.hpp>
 
-// coverity [root_function]
+// coverity[root_function]
 void test_main(int, char** argv, char**)
 {
     boost::nowide::nowide_filesystem();

--- a/test/test_fstream.cpp
+++ b/test/test_fstream.cpp
@@ -533,7 +533,7 @@ void test_flush(const std::string& filepath)
     TEST(!fo.seekg(0)); // Does not work on closed stream
 }
 
-// coverity [root_function]
+// coverity[root_function]
 void test_main(int, char** argv, char**)
 {
     const std::string exampleFilename = std::string(argv[0]) + "-\xd7\xa9-\xd0\xbc-\xce\xbd.txt";

--- a/test/test_fstream_special.cpp
+++ b/test/test_fstream_special.cpp
@@ -266,7 +266,7 @@ void testPutback(const char* filename)
     }
 }
 
-// coverity [root_function]
+// coverity[root_function]
 void test_main(int, char** argv, char**)
 {
     const std::string exampleFilename = std::string(argv[0]) + "-\xd7\xa9-\xd0\xbc-\xce\xbd.txt";

--- a/test/test_ifstream.cpp
+++ b/test/test_ifstream.cpp
@@ -199,7 +199,7 @@ void test_move_and_swap(const std::string& filename)
     }
 }
 
-// coverity [root_function]
+// coverity[root_function]
 void test_main(int, char** argv, char**)
 {
     const std::string exampleFilename = std::string(argv[0]) + "-\xd7\xa9-\xd0\xbc-\xce\xbd.txt";

--- a/test/test_iostream.cpp
+++ b/test/test_iostream.cpp
@@ -526,7 +526,7 @@ void test_console()
 #endif
 #endif
 
-// coverity [root_function]
+// coverity[root_function]
 void test_main(int argc, char** argv, char**)
 {
     // LCOV_EXCL_START

--- a/test/test_ofstream.cpp
+++ b/test/test_ofstream.cpp
@@ -202,7 +202,7 @@ void test_reopen(const std::string& filename)
     TEST_EQ(read_file(filename3, data_type::binary), testData3);
 }
 
-// coverity [root_function]
+// coverity[root_function]
 void test_main(int, char** argv, char**)
 {
     const std::string exampleFilename = std::string(argv[0]) + "-\xd7\xa9-\xd0\xbc-\xce\xbd.txt";

--- a/test/test_stackstring.cpp
+++ b/test/test_stackstring.cpp
@@ -62,7 +62,7 @@ std::string heap_stackstring_to_narrow(const std::wstring& s)
     return ss.get();
 }
 
-// coverity [root_function]
+// coverity[root_function]
 void test_main(int, char**, char**)
 {
     std::string hello = "\xd7\xa9\xd7\x9c\xd7\x95\xd7\x9d";

--- a/test/test_stat.cpp
+++ b/test/test_stat.cpp
@@ -13,7 +13,7 @@
 #include <errno.h>
 #endif
 
-// coverity [root_function]
+// coverity[root_function]
 void test_main(int, char** argv, char**)
 {
     const std::string prefix = argv[0];

--- a/test/test_stdio.cpp
+++ b/test/test_stdio.cpp
@@ -49,7 +49,7 @@ void noop_invalid_param_handler(const wchar_t*, const wchar_t*, const wchar_t*, 
 {} // LCOV_EXCL_LINE
 #endif
 
-// coverity [root_function]
+// coverity[root_function]
 void test_main(int, char** argv, char**)
 {
     const std::string prefix = argv[0];

--- a/test/test_system.cpp
+++ b/test/test_system.cpp
@@ -141,7 +141,7 @@ void run_parent(const std::string& exe_path)
 #endif
 }
 
-// coverity [root_function]
+// coverity[root_function]
 void test_main(int argc, char** argv, char** env)
 {
     const int old_argc = argc;

--- a/test/test_traits.cpp
+++ b/test/test_traits.cpp
@@ -53,7 +53,7 @@ static_assert(get_data_width<std::wstring>::value == sizeof(wchar_t), "!");
 static_assert(get_data_width<std::u16string>::value == sizeof(char16_t), "!");
 static_assert(get_data_width<std::u32string>::value == sizeof(char32_t), "!");
 
-// coverity [root_function]
+// coverity[root_function]
 void test_main(int, char**, char**)
 {
 #ifdef BOOST_NOWIDE_TEST_STD_STRINGVIEW


### PR DESCRIPTION
- `cov-configure --msvc` is required to configure coverity for MSVC
- `PublishCoverity` seems to be so outdated that manual commands (zipping via 7z then upload via curl) work better
- Fix and add a few supressions