### PR TITLE
Add filebuf::open overload accepting a path object and tests for const path::value_type*

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,22 @@ jobs:
           sudo apt-get install doxygen
           doc/gendoc.sh
           tar -czf documentation.tar.gz doc index.html
+
       - name: Create standalone version
         run: |
           bash tools/create_standalone.sh nowide_standalone_${{steps.get_tag.outputs.tag}}
           tar -czf  nowide_standalone.tar.gz nowide_standalone_${{steps.get_tag.outputs.tag}}
+      - name: Test standalone release tarball
+        run: |
+          tmp_dir=$(mktemp -d -p "$RUNNER_TEMP")
+          cd "$tmp_dir"
+          tar -xf "${{github.workspace}}/nowide_standalone.tar.gz"
+          src_dir="$PWD/nowide_standalone_${{steps.get_tag.outputs.tag}}"
+          mkdir build && cd build
+          cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/../install "$src_dir"
+          cmake --build . --config Debug --target install
+          ctest --output-on-failure -C Debug --verbose
+
       - name: Create Boost version
         run: |
             FOLDER="nowide_${{steps.get_tag.outputs.tag}}"
@@ -65,6 +77,7 @@ jobs:
           cmake -DBoost_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/../install "$src_dir"
           cmake --build . --config Debug --target install
           ctest --output-on-failure -C Debug --verbose
+
       - name: Create Release
         if: github.event_name == 'push'
         id: create_release

--- a/include/boost/nowide/filebuf.hpp
+++ b/include/boost/nowide/filebuf.hpp
@@ -12,6 +12,7 @@
 #include <boost/nowide/config.hpp>
 #if BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT
 #include <boost/nowide/cstdio.hpp>
+#include <boost/nowide/detail/is_path.hpp>
 #include <boost/nowide/stackstring.hpp>
 #include <cassert>
 #include <cstdio>
@@ -160,6 +161,11 @@ namespace nowide {
             mode_ = mode;
             set_unbuffered_read();
             return this;
+        }
+        template<typename Path>
+        detail::enable_if_path_t<Path, basic_filebuf*> open(const Path& file_name, std::ios_base::openmode mode)
+        {
+            return open(file_name.c_str(), mode);
         }
         ///
         /// Same as std::filebuf::close()

--- a/test/test_traits.cpp
+++ b/test/test_traits.cpp
@@ -8,6 +8,7 @@
 
 #include <boost/nowide/detail/is_path.hpp>
 #include <boost/nowide/detail/is_string_container.hpp>
+#include <boost/nowide/fstream.hpp>
 #include "test.hpp"
 #include <iostream>
 #include <string>
@@ -28,6 +29,11 @@
 #include <filesystem>
 #define BOOST_NOWIDE_TEST_STD_PATH
 #endif
+#if defined(__cpp_lib_experimental_filesystem)
+#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
+#include <experimental/filesystem>
+#define BOOST_NOWIDE_TEST_STD_EXPERIMENTAL_PATH
+#endif
 
 #ifdef BOOST_NOWIDE_TEST_BFS_PATH
 #if defined(__GNUC__) && __GNUC__ >= 7
@@ -38,6 +44,17 @@
 #endif
 #include <boost/filesystem/path.hpp>
 #endif
+
+template<class T_Class, class T_Arg, typename = void>
+struct has_open : std::false_type
+{};
+using boost::nowide::detail::void_t;
+template<class T_Class, class T_Arg>
+struct has_open<T_Class,
+                T_Arg,
+                void_t<decltype(std::declval<T_Class>().open(std::declval<T_Arg>(), std::ios_base::openmode{}))>>
+    : std::true_type
+{};
 
 using boost::nowide::detail::is_string_container;
 static_assert(is_string_container<std::string, true>::value, "!");
@@ -65,10 +82,65 @@ void test_main(int, char**, char**)
 #endif
 #ifdef BOOST_NOWIDE_TEST_STD_PATH
     std::cout << "Testing std::filesystem::path" << std::endl;
-    static_assert(boost::nowide::detail::is_path<std::filesystem::path>::value, "!");
+    using fs_path = std::filesystem::path;
+    static_assert(boost::nowide::detail::is_path<fs_path>::value, "!");
+#if BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT
+    static_assert(has_open<boost::nowide::filebuf, fs_path>::value, "!");
+#endif
+    static_assert(has_open<boost::nowide::ifstream, fs_path>::value, "!");
+    static_assert(has_open<boost::nowide::ofstream, fs_path>::value, "!");
+    static_assert(has_open<boost::nowide::fstream, fs_path>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::ifstream, fs_path>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::ofstream, fs_path>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::fstream, fs_path>::value, "!");
+    static_assert(has_open<boost::nowide::filebuf, const fs_path::value_type*>::value, "!");
+    static_assert(has_open<boost::nowide::ifstream, const fs_path::value_type*>::value, "!");
+    static_assert(has_open<boost::nowide::ofstream, const fs_path::value_type*>::value, "!");
+    static_assert(has_open<boost::nowide::fstream, const fs_path::value_type*>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::ifstream, const fs_path::value_type*>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::ofstream, const fs_path::value_type*>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::fstream, const fs_path::value_type*>::value, "!");
+#endif
+#ifdef BOOST_NOWIDE_TEST_STD_EXPERIMENTAL_PATH
+    std::cout << "Testing std::experimental::filesystem::path" << std::endl;
+    using exfs_path = std::experimental::filesystem::path;
+    static_assert(boost::nowide::detail::is_path<exfs_path>::value, "!");
+#if BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT
+    static_assert(has_open<boost::nowide::filebuf, exfs_path>::value, "!");
+#endif
+    static_assert(has_open<boost::nowide::ifstream, exfs_path>::value, "!");
+    static_assert(has_open<boost::nowide::ofstream, exfs_path>::value, "!");
+    static_assert(has_open<boost::nowide::fstream, exfs_path>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::ifstream, exfs_path>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::ofstream, exfs_path>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::fstream, exfs_path>::value, "!");
+    static_assert(has_open<boost::nowide::filebuf, const exfs_path::value_type*>::value, "!");
+    static_assert(has_open<boost::nowide::ifstream, const exfs_path::value_type*>::value, "!");
+    static_assert(has_open<boost::nowide::ofstream, const exfs_path::value_type*>::value, "!");
+    static_assert(has_open<boost::nowide::fstream, const exfs_path::value_type*>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::ifstream, const exfs_path::value_type*>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::ofstream, const exfs_path::value_type*>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::fstream, const exfs_path::value_type*>::value, "!");
 #endif
 #ifdef BOOST_NOWIDE_TEST_BFS_PATH
     std::cout << "Testing boost::filesystem::path" << std::endl;
-    static_assert(boost::nowide::detail::is_path<boost::filesystem::path>::value, "!");
+    using bfs_path = boost::filesystem::path;
+    static_assert(boost::nowide::detail::is_path<bfs_path>::value, "!");
+#if BOOST_NOWIDE_USE_FILEBUF_REPLACEMENT
+    static_assert(has_open<boost::nowide::filebuf, bfs_path>::value, "!");
+#endif
+    static_assert(has_open<boost::nowide::ifstream, bfs_path>::value, "!");
+    static_assert(has_open<boost::nowide::ofstream, bfs_path>::value, "!");
+    static_assert(has_open<boost::nowide::fstream, bfs_path>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::ifstream, bfs_path>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::ofstream, bfs_path>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::fstream, bfs_path>::value, "!");
+    static_assert(has_open<boost::nowide::filebuf, const bfs_path::value_type*>::value, "!");
+    static_assert(has_open<boost::nowide::ifstream, const bfs_path::value_type*>::value, "!");
+    static_assert(has_open<boost::nowide::ofstream, const bfs_path::value_type*>::value, "!");
+    static_assert(has_open<boost::nowide::fstream, const bfs_path::value_type*>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::ifstream, const bfs_path::value_type*>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::ofstream, const bfs_path::value_type*>::value, "!");
+    static_assert(std::is_constructible<boost::nowide::fstream, const bfs_path::value_type*>::value, "!");
 #endif
 }


### PR DESCRIPTION
Add filebuf::open overload accepting a path object to catch up with C++17 `std` classes

Add some `static_assert`s checking that the filebuf and fstream classes
can be used with `const *::filesystem::path::value_type*` and `::filesystem::path&` 
Closes #153