### PR TITLE
Fix potential macro redefinition in test_traits

### DIFF
--- a/test/test_traits.cpp
+++ b/test/test_traits.cpp
@@ -28,7 +28,9 @@
 #define BOOST_NOWIDE_TEST_STD_PATH
 #endif
 #if defined(__cpp_lib_experimental_filesystem)
+#ifndef _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
 #define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
+#endif
 #include <experimental/filesystem>
 #define BOOST_NOWIDE_TEST_STD_EXPERIMENTAL_PATH
 #endif


### PR DESCRIPTION
Check that `_SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING` is not defined already before defining it to avoid a warning (e.g. C4005 on MSVC)

Fixes #165