### PR TITLE
CMake: Build tests only on `make test`

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -177,7 +177,7 @@ for:
       - mkdir __build_cmake_test__
       - cd __build_cmake_test__
       - cmake -G "%GENERATOR%" -DCMAKE_CXX_STANDARD=%CXXSTD% %CMAKE_FLAGS% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ..
-    build_script: cmake --build . --config %configuration% --parallel 4
+    build_script: cmake --build . --config %configuration% --parallel 4 --target tests
     test_script:
       - ctest --output-on-failure -C %configuration% --parallel 4
       - ps: |
@@ -204,7 +204,7 @@ for:
       - cmake -G "%GENERATOR%" ..
       - ps: |
             cov-configure --msvc
-            cov-build --dir cov-int cmake --build . --config $env:configuration
+            cov-build --dir cov-int cmake --build --target tests . --config $env:configuration
             If ($LastExitCode -ne 0) {
               cat cov-int/build-log.txt
               $host.SetShouldExit($LastExitCode)

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -1,4 +1,4 @@
-# Copyright 2019 - 2022 Alexander Grund
+# Copyright 2019 - 2024 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # https://www.boost.org/LICENSE_1_0.txt
 
@@ -102,8 +102,8 @@ jobs:
           extraFlags="$extraFlags -DCMAKE_CXX_FLAGS=-Wundef"
         fi
         cmake -DCMAKE_BUILD_TYPE=${{matrix.buildType}} -DBUILD_SHARED_LIBS=${{matrix.shared_lib}} -G "${{matrix.generator}}" $extraFlags ..
-    - name: Build & Install
-      run: cmake --build build --config ${{matrix.buildType}} --target install
+    - name: Build
+      run: cmake --build build --config ${{matrix.buildType}} --target tests
 
     # Run test with both bash and powershell and watch for "Using std::cin" on bash but not on powershell
     - name: Test
@@ -114,6 +114,9 @@ jobs:
       shell: powershell
       if: runner.os == 'Windows'
       run: ctest --output-on-failure -C ${{matrix.buildType}} --verbose
+
+    - name: Install
+      run: cmake --build build --config ${{matrix.buildType}} --target install
     - name: Test consumption
       working-directory: build
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,9 @@ jobs:
           src_dir="$PWD/nowide_standalone_${{steps.get_tag.outputs.tag}}"
           mkdir build && cd build
           cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/../install "$src_dir"
-          cmake --build . --config Debug --target install
+          cmake --build . --config Debug --target tests
           ctest --output-on-failure -C Debug --verbose
+          cmake --build . --config Debug --target install
 
       - name: Create Boost version
         run: |
@@ -75,8 +76,9 @@ jobs:
           src_dir="$PWD/nowide_${{steps.get_tag.outputs.tag}}"
           mkdir build && cd build
           cmake -DBoost_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=${{runner.workspace}}/../install "$src_dir"
-          cmake --build . --config Debug --target install
+          cmake --build . --config Debug --target tests
           ctest --output-on-failure -C Debug --verbose
+          cmake --build . --config Debug --target install
 
       - name: Create Release
         if: github.event_name == 'push'

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,11 @@
-# Copyright 2019 - 2021 Alexander Grund
+# Copyright 2019 - 2024 Alexander Grund
 # Distributed under the Boost Software License, Version 1.0.
 # https://www.boost.org/LICENSE_1_0.txt
 
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-Wsuggest-override _BOOST_NOWIDE_SUGGEST_OVERRIDE_SUPPORTED)
 
-add_library(boost_nowide_file_test_helpers STATIC file_test_helpers.cpp)
+add_library(boost_nowide_file_test_helpers STATIC EXCLUDE_FROM_ALL file_test_helpers.cpp)
 target_link_libraries(boost_nowide_file_test_helpers PRIVATE Boost::nowide)
 target_compile_definitions(boost_nowide_file_test_helpers PRIVATE BOOST_ALL_NO_LIB)
 
@@ -27,7 +27,7 @@ function(boost_nowide_add_test name)
   endif()
   set(name ${PROJECT_NAME}-${name})
   
-  add_executable(${name} ${ARG_SRC})
+  add_executable(${name} EXCLUDE_FROM_ALL ${ARG_SRC})
   add_dependencies(tests ${name})
   target_link_libraries(${name} PRIVATE Boost::nowide ${ARG_LIBRARIES})
   boost_add_warnings(${name} pedantic ${Boost_NOWIDE_WERROR})


### PR DESCRIPTION
Add EXCLUDE_FROM_ALL to test binaries as per the Boost convention

Fixes #181 