### PR TITLE
cmake: cmake_minimum_required 3.10 (3.9 is deprecated for cmake 3.31 onwards)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 #
 # When not using CMake to link against the shared library on windows define -DBOOST_NOWIDE_DYN_LINK
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.10)
 # Version number starts at 10 to avoid conflicts with Boost version
 set(_version 11.3.0)
 if(BOOST_SUPERPROJECT_SOURCE_DIR)


### PR DESCRIPTION
The current version of make is 4.1.1

It's complaining that cmake 3.9 policy [is deprecated](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-version) since 3.31

This change brings the minimum cmake requirement to 3.10 (Nov 2017).

Boost more broadly needs cmake 3.20 (Apr 2021) or newer to build monolithically.